### PR TITLE
perf(data): add AsNoTracking to read-only queries for performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enhanced IDE-specific file exclusions
   - Better organization with categorized sections
 
+#### Performance Optimizations with AsNoTracking
+- **Added** `.AsNoTracking()` to all read-only database queries for performance improvement
+  - Applied to AccountRepository for student and instructor retrieval methods
+  - Applied to StudentEnrollmentRepository for all read operations
+  - Applied to AccountService for user profile retrieval
+  - Applied to BlacklistedTokenCleanupService for expired token cleanup
+  - Applied to ScheduleService for validation queries
+  - Applied to TokenValidationService for token validation
+  - Significantly reduces entity tracking overhead for read operations
+  - Improves response times and memory usage for frequently accessed data
+
 #### User Model Architecture Enhancement
 - **Removed** redundant email fields from user models
   - Removed `Email` property from `Admin`, `Instructor`, and `Student` model classes

--- a/attendance_monitoring/Repositories/AccountRepository.cs
+++ b/attendance_monitoring/Repositories/AccountRepository.cs
@@ -170,6 +170,7 @@ namespace attendance_monitoring.Repositories
         public async Task<Student?> GetStudentByUserIdAsync(string userId)
         {
             return await context.Students
+                .AsNoTracking()
                 .Include(s => s.Section)
                 .ThenInclude(s => s.Course)
                 .FirstOrDefaultAsync(s => s.UserId == userId && !s.IsDeleted)
@@ -181,6 +182,7 @@ namespace attendance_monitoring.Repositories
         public async Task<Instructor?> GetInstructorByUserIdAsync(string userId)
         {
             return await context.Instructors
+                .AsNoTracking()
                 .FirstOrDefaultAsync(i => i.UserId == userId && !i.IsDeleted)
                 .ConfigureAwait(false);
         }

--- a/attendance_monitoring/Repositories/StudentEnrollmentRepository.cs
+++ b/attendance_monitoring/Repositories/StudentEnrollmentRepository.cs
@@ -17,6 +17,7 @@ public class StudentEnrollmentRepository : IStudentEnrollmentRepository
     public async Task<IEnumerable<StudentEnrollment>> GetAllAsync()
     {
         return await _context.StudentEnrollments
+            .AsNoTracking()
             .Include(se => se.Student)
                 .ThenInclude(s => s.User)
             .Include(se => se.Section)
@@ -27,6 +28,7 @@ public class StudentEnrollmentRepository : IStudentEnrollmentRepository
     public async Task<StudentEnrollment?> GetByIdAsync(int id)
     {
         return await _context.StudentEnrollments
+            .AsNoTracking()
             .Include(se => se.Student)
                 .ThenInclude(s => s.User)
             .Include(se => se.Section)
@@ -68,6 +70,7 @@ public class StudentEnrollmentRepository : IStudentEnrollmentRepository
     public async Task<IEnumerable<StudentEnrollment>> GetStudentEnrollmentsAsync(int studentId)
     {
         return await _context.StudentEnrollments
+            .AsNoTracking()
             .Include(se => se.Section)
             .Include(se => se.Subject)
             .Where(se => se.StudentId == studentId)
@@ -77,6 +80,7 @@ public class StudentEnrollmentRepository : IStudentEnrollmentRepository
     public async Task<IEnumerable<StudentEnrollment>> GetSectionEnrollmentsAsync(int sectionId)
     {
         return await _context.StudentEnrollments
+            .AsNoTracking()
             .Include(se => se.Student)
                 .ThenInclude(s => s.User)
             .Include(se => se.Subject)
@@ -87,6 +91,7 @@ public class StudentEnrollmentRepository : IStudentEnrollmentRepository
     public async Task<IEnumerable<StudentEnrollment>> GetSubjectEnrollmentsAsync(int subjectId)
     {
         return await _context.StudentEnrollments
+            .AsNoTracking()
             .Include(se => se.Student)
                 .ThenInclude(s => s.User)
             .Include(se => se.Section)
@@ -97,6 +102,7 @@ public class StudentEnrollmentRepository : IStudentEnrollmentRepository
     public async Task<IEnumerable<StudentEnrollment>> GetActiveSectionEnrollmentsAsync(int sectionId)
     {
         return await _context.StudentEnrollments
+            .AsNoTracking()
             .Include(se => se.Student)
                 .ThenInclude(s => s.User)
             .Include(se => se.Section)
@@ -108,6 +114,7 @@ public class StudentEnrollmentRepository : IStudentEnrollmentRepository
     public async Task<IEnumerable<StudentEnrollment>> GetActiveSubjectEnrollmentsAsync(int subjectId)
     {
         return await _context.StudentEnrollments
+            .AsNoTracking()
             .Include(se => se.Student)
                 .ThenInclude(s => s.User)
             .Include(se => se.Section)
@@ -118,6 +125,7 @@ public class StudentEnrollmentRepository : IStudentEnrollmentRepository
     public async Task<StudentEnrollment?> GetEnrollmentAsync(int studentId, int sectionId, int subjectId)
     {
         return await _context.StudentEnrollments
+            .AsNoTracking()
             .Include(se => se.Student)
                 .ThenInclude(s => s.User)
             .Include(se => se.Section)
@@ -129,16 +137,18 @@ public class StudentEnrollmentRepository : IStudentEnrollmentRepository
 
     public async Task<bool> IsStudentEnrolledAsync(int studentId, int sectionId, int subjectId)
     {
-        return await _context.StudentEnrollments
-            .AnyAsync(se => se.StudentId == studentId && 
-                      se.SectionId == sectionId && 
-                      se.SubjectId == subjectId && 
-                      se.IsActive);
+    return await _context.StudentEnrollments
+    .AsNoTracking()
+    .AnyAsync(se => se.StudentId == studentId &&
+    se.SectionId == sectionId &&
+    se.SubjectId == subjectId &&
+                       se.IsActive);
     }
 
     public async Task<IEnumerable<StudentEnrollment>> GetActiveEnrollmentsAsync(int studentId)
     {
         return await _context.StudentEnrollments
+            .AsNoTracking()
             .Include(se => se.Section)
             .Include(se => se.Subject)
             .Where(se => se.StudentId == studentId && se.IsActive)
@@ -148,6 +158,7 @@ public class StudentEnrollmentRepository : IStudentEnrollmentRepository
     public async Task<IEnumerable<Section>> GetStudentSectionsAsync(int studentId)
     {
         return await _context.StudentEnrollments
+            .AsNoTracking()
             .Include(se => se.Section)
             .Where(se => se.StudentId == studentId && se.IsActive)
             .Select(se => se.Section)
@@ -158,6 +169,7 @@ public class StudentEnrollmentRepository : IStudentEnrollmentRepository
     public async Task<IEnumerable<Subject>> GetStudentSubjectsAsync(int studentId)
     {
         return await _context.StudentEnrollments
+            .AsNoTracking()
             .Include(se => se.Subject)
             .Where(se => se.StudentId == studentId && se.IsActive)
             .Select(se => se.Subject)

--- a/attendance_monitoring/Services/AccountService.cs
+++ b/attendance_monitoring/Services/AccountService.cs
@@ -542,6 +542,7 @@ namespace attendance_monitoring.Services
             if (role.Equals("Student", StringComparison.OrdinalIgnoreCase))
             {
                 var student = await context.Students
+                    .AsNoTracking()
                     .Include(s => s.User)
                     .Include(s => s.Section)
                         .ThenInclude(sec => sec.Course)

--- a/attendance_monitoring/Services/BlacklistedTokenCleanupService.cs
+++ b/attendance_monitoring/Services/BlacklistedTokenCleanupService.cs
@@ -31,6 +31,7 @@ public class BlacklistedTokenCleanupService : BackgroundService
 
                 // Remove expired blacklisted tokens
                 var expiredTokens = await context.BlacklistedTokens
+                    .AsNoTracking()
                     .Where(bt => bt.ExpiresAt < DateTime.UtcNow)
                     .ToListAsync(stoppingToken).ConfigureAwait(false);
 

--- a/attendance_monitoring/Services/ScheduleService.cs
+++ b/attendance_monitoring/Services/ScheduleService.cs
@@ -85,28 +85,28 @@ namespace attendance_monitoring.Services
             try
             {
                 // Validate relationships if needed
-                var subjectExists = await context.Subjects.AnyAsync(s => s.Id == createSchedule.SubjectId);
+                var subjectExists = await context.Subjects.AsNoTracking().AnyAsync(s => s.Id == createSchedule.SubjectId);
                 if (!subjectExists)
                 {
                     logger.LogWarning("Schedule creation failed: Subject with ID {SubjectId} not found", createSchedule.SubjectId);
                     return (null, "Subject not found");
                 }
 
-                var classroomExists = await context.Classrooms.AnyAsync(c => c.Id == createSchedule.ClassroomId);
+                var classroomExists = await context.Classrooms.AsNoTracking().AnyAsync(c => c.Id == createSchedule.ClassroomId);
                 if (!classroomExists)
                 {
                     logger.LogWarning("Schedule creation failed: Classroom with ID {ClassroomId} not found", createSchedule.ClassroomId);
                     return (null, "Classroom not found");
                 }
 
-                var sectionExists = await context.Sections.AnyAsync(s => s.Id == createSchedule.SectionId);
+                var sectionExists = await context.Sections.AsNoTracking().AnyAsync(s => s.Id == createSchedule.SectionId);
                 if (!sectionExists)
                 {
                     logger.LogWarning("Schedule creation failed: Section with ID {SectionId} not found", createSchedule.SectionId);
                     return (null, "Section not found");
                 }
 
-                var instructorExists = await context.Instructors.AnyAsync(i => i.Id == createSchedule.InstructorId);
+                var instructorExists = await context.Instructors.AsNoTracking().AnyAsync(i => i.Id == createSchedule.InstructorId);
                 if (!instructorExists)
                 {
                     logger.LogWarning("Schedule creation failed: Instructor with ID {InstructorId} not found", createSchedule.InstructorId);
@@ -155,28 +155,28 @@ namespace attendance_monitoring.Services
                 }
 
                 // Validate relationships if needed
-                var subjectExists = await context.Subjects.AnyAsync(s => s.Id == updateSchedule.SubjectId);
+                var subjectExists = await context.Subjects.AsNoTracking().AnyAsync(s => s.Id == updateSchedule.SubjectId);
                 if (!subjectExists)
                 {
                     logger.LogWarning("Schedule update failed: Subject with ID {SubjectId} not found", updateSchedule.SubjectId);
                     return (null, "Subject not found");
                 }
 
-                var classroomExists = await context.Classrooms.AnyAsync(c => c.Id == updateSchedule.ClassroomId);
+                var classroomExists = await context.Classrooms.AsNoTracking().AnyAsync(c => c.Id == updateSchedule.ClassroomId);
                 if (!classroomExists)
                 {
                     logger.LogWarning("Schedule update failed: Classroom with ID {ClassroomId} not found", updateSchedule.ClassroomId);
                     return (null, "Classroom not found");
                 }
 
-                var sectionExists = await context.Sections.AnyAsync(s => s.Id == updateSchedule.SectionId);
+                var sectionExists = await context.Sections.AsNoTracking().AnyAsync(s => s.Id == updateSchedule.SectionId);
                 if (!sectionExists)
                 {
                     logger.LogWarning("Schedule update failed: Section with ID {SectionId} not found", updateSchedule.SectionId);
                     return (null, "Section not found");
                 }
 
-                var instructorExists = await context.Instructors.AnyAsync(i => i.Id == updateSchedule.InstructorId);
+                var instructorExists = await context.Instructors.AsNoTracking().AnyAsync(i => i.Id == updateSchedule.InstructorId);
                 if (!instructorExists)
                 {
                     logger.LogWarning("Schedule update failed: Instructor with ID {InstructorId} not found", updateSchedule.InstructorId);

--- a/attendance_monitoring/Services/TokenValidationService.cs
+++ b/attendance_monitoring/Services/TokenValidationService.cs
@@ -19,7 +19,7 @@ public class TokenValidationService : ITokenValidationService
     #region IsTokenBlacklistedAsync
     public async Task<bool> IsTokenBlacklistedAsync(string jti)
     {
-        return await _context.BlacklistedTokens.AnyAsync(bt => bt.Jti == jti).ConfigureAwait(false);
+        return await _context.BlacklistedTokens.AsNoTracking().AnyAsync(bt => bt.Jti == jti).ConfigureAwait(false);
     }
     #endregion
 


### PR DESCRIPTION
- optimize several repositories and services by adding AsNoTracking() to read-only queries or operations
- this avoids unnecessary entity tracking overhead
- updated changelog