### PR TITLE
feat(section): add conflict exception for fk violations

### DIFF
--- a/attendance.testproject/Controllers_Testing/SectionControllerTest.cs
+++ b/attendance.testproject/Controllers_Testing/SectionControllerTest.cs
@@ -1,6 +1,8 @@
 using attendance_monitoring.Controllers;
 using attendance_monitoring.Exceptions;
 using attendance_monitoring.IServices;
+using attendance_monitoring.Models.DTO.Response;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
@@ -65,5 +67,116 @@ public class SectionControllerTest
         var objectResult = Assert.IsType<ObjectResult>(result.Result);
         Assert.Equal(500, objectResult.StatusCode);
         Assert.Equal("An error occurred while checking section dependencies", objectResult.Value);
+    }
+
+    [Fact]
+    public async Task DeleteSection_ReturnsNoContent_WhenDeletionSucceeds()
+    {
+        // Arrange
+        const int sectionId = 1;
+        _mockSectionService
+            .Setup(service => service.DeleteSectionAsync(sectionId))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _controller.DeleteSection(sectionId);
+
+        // Assert
+        Assert.IsType<NoContentResult>(result);
+        _mockSectionService.Verify(service => service.DeleteSectionAsync(sectionId), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteSection_ReturnsNotFound_WhenSectionDoesNotExist()
+    {
+        // Arrange
+        const int sectionId = 1;
+        _mockSectionService
+            .Setup(service => service.DeleteSectionAsync(sectionId))
+            .ThrowsAsync(new EntityNotFoundException<int>("Section", sectionId));
+
+        // Act
+        var result = await _controller.DeleteSection(sectionId);
+
+        // Assert
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Equal($"Section with ID {sectionId} not found", notFoundResult.Value);
+    }
+
+    [Fact]
+    public async Task DeleteSection_ReturnsConflict_WithErrorResponseDto_WhenBlockedByDependencies()
+    {
+        // Arrange
+        const int sectionId = 1;
+        const string conflictMessage = "Cannot delete: Section has schedules assigned. Remove schedules first.";
+        _mockSectionService
+            .Setup(service => service.DeleteSectionAsync(sectionId))
+            .ThrowsAsync(new EntityConflictException("Section", "schedules", conflictMessage));
+
+        // Act
+        var result = await _controller.DeleteSection(sectionId);
+
+        // Assert
+        var conflictResult = Assert.IsType<ConflictObjectResult>(result);
+        var errorResponse = Assert.IsType<ErrorResponseDto>(conflictResult.Value);
+        Assert.False(errorResponse.Success);
+        Assert.Equal(conflictMessage, errorResponse.Message);
+        Assert.Equal(StatusCodes.Status409Conflict, errorResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteSection_ReturnsConflict_WithEnrollmentsMessage_WhenBlockedByEnrollments()
+    {
+        // Arrange
+        const int sectionId = 1;
+        const string conflictMessage = "Cannot delete: Section has student enrollments. Remove enrollments first.";
+        _mockSectionService
+            .Setup(service => service.DeleteSectionAsync(sectionId))
+            .ThrowsAsync(new EntityConflictException("Section", "enrollments", conflictMessage));
+
+        // Act
+        var result = await _controller.DeleteSection(sectionId);
+
+        // Assert
+        var conflictResult = Assert.IsType<ConflictObjectResult>(result);
+        var errorResponse = Assert.IsType<ErrorResponseDto>(conflictResult.Value);
+        Assert.Equal(conflictMessage, errorResponse.Message);
+    }
+
+    [Fact]
+    public async Task DeleteSection_ReturnsConflict_WithStudentsMessage_WhenBlockedByStudents()
+    {
+        // Arrange
+        const int sectionId = 1;
+        const string conflictMessage = "Cannot delete: Section has assigned students. Reassign students first.";
+        _mockSectionService
+            .Setup(service => service.DeleteSectionAsync(sectionId))
+            .ThrowsAsync(new EntityConflictException("Section", "students", conflictMessage));
+
+        // Act
+        var result = await _controller.DeleteSection(sectionId);
+
+        // Assert
+        var conflictResult = Assert.IsType<ConflictObjectResult>(result);
+        var errorResponse = Assert.IsType<ErrorResponseDto>(conflictResult.Value);
+        Assert.Equal(conflictMessage, errorResponse.Message);
+    }
+
+    [Fact]
+    public async Task DeleteSection_ReturnsServerError_ForUnexpectedServiceException()
+    {
+        // Arrange
+        const int sectionId = 1;
+        _mockSectionService
+            .Setup(service => service.DeleteSectionAsync(sectionId))
+            .ThrowsAsync(new EntityServiceException("Section", $"DeleteSection: {sectionId}", "Database connection failed"));
+
+        // Act
+        var result = await _controller.DeleteSection(sectionId);
+
+        // Assert
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(500, objectResult.StatusCode);
+        Assert.Equal("An error occurred while deleting the section", objectResult.Value);
     }
 }

--- a/attendance.testproject/Services_Testing/SectionServiceTest.cs
+++ b/attendance.testproject/Services_Testing/SectionServiceTest.cs
@@ -202,4 +202,29 @@ public class SectionServiceTest
         Assert.Equal("Section", exception.EntityName);
         Assert.Equal("schedules", exception.ConflictType);
     }
+
+    [Fact]
+    public async Task DeleteSectionAsync_GenericConstraintViolation_ThrowsEntityServiceException()
+    {
+        // Arrange
+        const int sectionId = 1;
+        _mockSectionRepository
+            .Setup(repository => repository.DeleteSectionAsync(sectionId))
+            .ReturnsAsync(true);
+
+        // A constraint violation that is NOT a foreign key violation
+        // This should NOT be matched as a dependency conflict
+        var innerException = new Exception("constraint violation: value violates check constraint \"CK_Sections_NameNotEmpty\"");
+        var dbUpdateException = new DbUpdateException("Update exception", innerException);
+
+        _mockSectionRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ThrowsAsync(dbUpdateException);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteSectionAsync(sectionId));
+        Assert.Equal("Section", exception.EntityName);
+        Assert.Equal($"DeleteSection: {sectionId}", exception.Operation);
+        Assert.Same(dbUpdateException, exception.InnerException);
+    }
 }

--- a/attendance.testproject/Services_Testing/SectionServiceTest.cs
+++ b/attendance.testproject/Services_Testing/SectionServiceTest.cs
@@ -1,6 +1,7 @@
 using attendance_monitoring.Exceptions;
 using attendance_monitoring.IRepository;
 using attendance_monitoring.Services;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace attendance.testproject.Services_Testing;
@@ -53,5 +54,152 @@ public class SectionServiceTest
         Assert.Equal($"HasSchedulesInSection: {sectionId}", exception.Operation);
         Assert.Equal("Error checking section dependencies", exception.Message);
         Assert.Same(expectedException, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task DeleteSectionAsync_Success_DeletesSection()
+    {
+        // Arrange
+        const int sectionId = 1;
+        _mockSectionRepository
+            .Setup(repository => repository.DeleteSectionAsync(sectionId))
+            .ReturnsAsync(true);
+        _mockSectionRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        // Act
+        await _service.DeleteSectionAsync(sectionId);
+
+        // Assert
+        _mockSectionRepository.Verify(repository => repository.DeleteSectionAsync(sectionId), Times.Once);
+        _mockSectionRepository.Verify(repository => repository.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteSectionAsync_NotFound_ThrowsEntityNotFoundException()
+    {
+        // Arrange
+        const int sectionId = 1;
+        _mockSectionRepository
+            .Setup(repository => repository.DeleteSectionAsync(sectionId))
+            .ReturnsAsync(false);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<int>>(() => _service.DeleteSectionAsync(sectionId));
+        Assert.Equal("Section", exception.EntityName);
+        Assert.Equal(sectionId, exception.Key);
+    }
+
+    [Fact]
+    public async Task DeleteSectionAsync_SchedulesConflict_ThrowsEntityConflictException()
+    {
+        // Arrange
+        const int sectionId = 1;
+        _mockSectionRepository
+            .Setup(repository => repository.DeleteSectionAsync(sectionId))
+            .ReturnsAsync(true);
+
+        var innerException = new Exception("The DELETE statement conflicted with the REFERENCE constraint \"FK_Schedules_Sections\". The conflict occurred in database \"attendance_db\", table \"dbo.Schedules\"");
+        var dbUpdateException = new DbUpdateException("Update exception", innerException);
+
+        _mockSectionRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ThrowsAsync(dbUpdateException);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityConflictException>(() => _service.DeleteSectionAsync(sectionId));
+        Assert.Equal("Section", exception.EntityName);
+        Assert.Equal("schedules", exception.ConflictType);
+        Assert.Contains("schedules", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DeleteSectionAsync_StudentsConflict_ThrowsEntityConflictException()
+    {
+        // Arrange
+        const int sectionId = 1;
+        _mockSectionRepository
+            .Setup(repository => repository.DeleteSectionAsync(sectionId))
+            .ReturnsAsync(true);
+
+        var innerException = new Exception("The DELETE statement conflicted with the REFERENCE constraint \"FK_Students_Sections\". The conflict occurred in database \"attendance_db\", table \"dbo.Students\"");
+        var dbUpdateException = new DbUpdateException("Update exception", innerException);
+
+        _mockSectionRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ThrowsAsync(dbUpdateException);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityConflictException>(() => _service.DeleteSectionAsync(sectionId));
+        Assert.Equal("Section", exception.EntityName);
+        Assert.Equal("students", exception.ConflictType);
+        Assert.Contains("students", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DeleteSectionAsync_EnrollmentsConflict_ThrowsEntityConflictException()
+    {
+        // Arrange
+        const int sectionId = 1;
+        _mockSectionRepository
+            .Setup(repository => repository.DeleteSectionAsync(sectionId))
+            .ReturnsAsync(true);
+
+        var innerException = new Exception("The DELETE statement conflicted with the REFERENCE constraint \"FK_StudentEnrollments_Sections\". The conflict occurred in database \"attendance_db\", table \"dbo.StudentEnrollments\"");
+        var dbUpdateException = new DbUpdateException("Update exception", innerException);
+
+        _mockSectionRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ThrowsAsync(dbUpdateException);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityConflictException>(() => _service.DeleteSectionAsync(sectionId));
+        Assert.Equal("Section", exception.EntityName);
+        Assert.Equal("enrollments", exception.ConflictType);
+        Assert.Contains("enrollments", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DeleteSectionAsync_UnrelatedException_ThrowsEntityServiceException()
+    {
+        // Arrange
+        const int sectionId = 1;
+        _mockSectionRepository
+            .Setup(repository => repository.DeleteSectionAsync(sectionId))
+            .ReturnsAsync(true);
+
+        var expectedException = new InvalidOperationException("Unexpected database error");
+        _mockSectionRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ThrowsAsync(expectedException);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteSectionAsync(sectionId));
+        Assert.Equal("Section", exception.EntityName);
+        Assert.Equal($"DeleteSection: {sectionId}", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task DeleteSectionAsync_PostgreSQLSchedulesConflict_ThrowsEntityConflictException()
+    {
+        // Arrange
+        const int sectionId = 1;
+        _mockSectionRepository
+            .Setup(repository => repository.DeleteSectionAsync(sectionId))
+            .ReturnsAsync(true);
+
+        var innerException = new Exception("23503: insert or update on table \"Schedules\" violates foreign key constraint \"FK_Schedules_Sections\"");
+        var dbUpdateException = new DbUpdateException("Update exception", innerException);
+
+        _mockSectionRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ThrowsAsync(dbUpdateException);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityConflictException>(() => _service.DeleteSectionAsync(sectionId));
+        Assert.Equal("Section", exception.EntityName);
+        Assert.Equal("schedules", exception.ConflictType);
     }
 }

--- a/attendance_monitoring/Controllers/SectionController.cs
+++ b/attendance_monitoring/Controllers/SectionController.cs
@@ -13,6 +13,18 @@ namespace attendance_monitoring.Controllers
     [Route("api/sections")]
     public class SectionController(ISectionService sectionService, ILogger<SectionController> logger) : ControllerBase
     {
+        private ErrorResponseDto CreateErrorResponse(string message, int statusCode)
+        {
+            return new ErrorResponseDto
+            {
+                Success = false,
+                Message = message,
+                StatusCode = statusCode,
+                Path = Request?.Path,
+                Timestamp = DateTime.UtcNow
+            };
+        }
+
         [HttpGet("{id:int}")]
         public async Task<ActionResult<SectionResponseDto>> GetSection(int id)
         {
@@ -124,6 +136,11 @@ namespace attendance_monitoring.Controllers
             {
                 logger.LogWarning(ex, "Section with ID {SectionId} not found for deletion", id);
                 return NotFound($"Section with ID {id} not found");
+            }
+            catch (EntityConflictException ex)
+            {
+                logger.LogWarning(ex, "Cannot delete section {SectionId}: {ConflictReason}", id, ex.Message);
+                return Conflict(CreateErrorResponse(ex.Message, StatusCodes.Status409Conflict));
             }
             catch (EntityServiceException ex)
             {

--- a/attendance_monitoring/Exceptions/EntityConflictException.cs
+++ b/attendance_monitoring/Exceptions/EntityConflictException.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Runtime.Serialization;
+
+namespace attendance_monitoring.Exceptions
+{
+    /// <summary>
+    /// Exception thrown when an entity operation fails due to a conflict with existing data,
+    /// such as foreign key constraint violations during delete operations.
+    /// </summary>
+    public class EntityConflictException : Exception
+    {
+        public string EntityName { get; }
+        public string ConflictType { get; }
+
+        /// <summary>
+        /// Creates a conflict exception with a message
+        /// </summary>
+        /// <param name="entityName">The name of the entity type (e.g., "Section", "Classroom")</param>
+        /// <param name="conflictType">The type of conflict (e.g., "schedules", "students", "enrollments")</param>
+        /// <param name="message">User-facing error message describing the conflict</param>
+        public EntityConflictException(string entityName, string conflictType, string message)
+            : base(message)
+        {
+            EntityName = entityName;
+            ConflictType = conflictType;
+        }
+
+        /// <summary>
+        /// Creates a conflict exception with a message and inner exception
+        /// </summary>
+        /// <param name="entityName">The name of the entity type (e.g., "Section", "Classroom")</param>
+        /// <param name="conflictType">The type of conflict (e.g., "schedules", "students", "enrollments")</param>
+        /// <param name="message">User-facing error message describing the conflict</param>
+        /// <param name="innerException">The underlying exception that caused the conflict</param>
+        public EntityConflictException(string entityName, string conflictType, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            EntityName = entityName;
+            ConflictType = conflictType;
+        }
+
+        /// <summary>
+        /// Serialization constructor for deserialization
+        /// </summary>
+        /// <param name="info">Serialization info</param>
+        /// <param name="context">Streaming context</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        protected EntityConflictException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            EntityName = info.GetString(nameof(EntityName))!;
+            ConflictType = info.GetString(nameof(ConflictType))!;
+        }
+
+        /// <summary>
+        /// Gets the object data for serialization
+        /// </summary>
+        /// <param name="info">Serialization info</param>
+        /// <param name="context">Streaming context</param>
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.")]
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue(nameof(EntityName), EntityName);
+            info.AddValue(nameof(ConflictType), ConflictType);
+        }
+    }
+}

--- a/attendance_monitoring/Helpers/ExceptionHandlingHelper.cs
+++ b/attendance_monitoring/Helpers/ExceptionHandlingHelper.cs
@@ -49,7 +49,7 @@ public static class ExceptionHandlingHelper
 
     /// <summary>
     /// Determines if the exception is caused by a foreign key constraint violation.
-    /// Supports both SQL Server and SQLite database providers.
+    /// Supports SQL Server, SQLite, and PostgreSQL database providers.
     /// </summary>
     /// <param name="ex">The DbUpdateException to analyze.</param>
     /// <returns>True if the exception is due to a foreign key constraint violation; otherwise, false.</returns>
@@ -68,6 +68,13 @@ public static class ExceptionHandlingHelper
 
         // SQLite foreign key violation
         if (innerException.Contains("FOREIGN KEY constraint failed"))
+        {
+            return true;
+        }
+
+        // PostgreSQL foreign key violation (SQLSTATE 23503)
+        if (innerException.Contains("violates foreign key constraint") ||
+            innerException.Contains("23503"))
         {
             return true;
         }

--- a/attendance_monitoring/Services/SectionService.cs
+++ b/attendance_monitoring/Services/SectionService.cs
@@ -3,6 +3,7 @@ using attendance_monitoring.Exceptions;
 using attendance_monitoring.IRepository;
 using attendance_monitoring.IServices;
 using attendance_monitoring.Models.DTO.Response;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace attendance_monitoring.Services
@@ -167,7 +168,8 @@ namespace attendance_monitoring.Services
         /// </summary>
         /// <param name="id">The ID of the section to delete</param>
         /// <exception cref="T:attendance_monitoring.Exceptions.EntityNotFoundException{System.Int32}">Thrown when the section is not found</exception>
-        /// <exception cref="EntityServiceException">Thrown when section deletion fails</exception>
+        /// <exception cref="EntityConflictException">Thrown when section deletion is blocked by existing dependencies</exception>
+        /// <exception cref="EntityServiceException">Thrown when section deletion fails unexpectedly</exception>
         public async Task DeleteSectionAsync(int id)
         {
             try
@@ -188,11 +190,66 @@ namespace attendance_monitoring.Services
                 // Re-throw EntityNotFoundException as-is
                 throw;
             }
+            catch (DbUpdateException ex) when (IsForeignKeyViolation(ex))
+            {
+                // Translate FK constraint violations into EntityConflictException
+                var conflictMessage = ResolveConflictMessage(ex);
+                logger.LogWarning(ex, "Cannot delete section {SectionId}: {ConflictMessage}", id, conflictMessage);
+                throw new EntityConflictException("Section", ResolveConflictType(ex), conflictMessage, ex);
+            }
             catch (Exception ex)
             {
                 logger.LogError(ex, "An error occurred while deleting section with ID {SectionId} from repository.", id);
                 throw new EntityServiceException("Section", $"DeleteSection: {id}", "An error occurred while deleting the section", ex);
             }
+        }
+
+        /// <summary>
+        /// Determines if a DbUpdateException represents a foreign key constraint violation.
+        /// </summary>
+        private static bool IsForeignKeyViolation(DbUpdateException ex)
+        {
+            // Check for SQL Server FK constraint violation (error number 547)
+            // or PostgreSQL FK violation (SQLSTATE 23503)
+            var innerMessage = ex.InnerException?.Message?.ToLowerInvariant() ?? string.Empty;
+            return innerMessage.Contains("foreign key") ||
+                   innerMessage.Contains("constraint") ||
+                   innerMessage.Contains("23503") ||
+                   innerMessage.Contains("547");
+        }
+
+        /// <summary>
+        /// Resolves the type of conflict based on the exception details.
+        /// </summary>
+        private static string ResolveConflictType(DbUpdateException ex)
+        {
+            var message = ex.InnerException?.Message?.ToLowerInvariant() ?? string.Empty;
+
+            if (message.Contains("schedule"))
+                return "schedules";
+            if (message.Contains("enrollment"))
+                return "enrollments";
+            if (message.Contains("student"))
+                return "students";
+
+            return "dependencies";
+        }
+
+        /// <summary>
+        /// Generates a user-friendly conflict message based on the exception details.
+        /// </summary>
+        private static string ResolveConflictMessage(DbUpdateException ex)
+        {
+            var message = ex.InnerException?.Message?.ToLowerInvariant() ?? string.Empty;
+
+            if (message.Contains("schedule"))
+                return "Cannot delete: Section has schedules assigned. Remove schedules first.";
+            if (message.Contains("enrollment"))
+                return "Cannot delete: Section has student enrollments. Remove enrollments first.";
+            if (message.Contains("student"))
+                return "Cannot delete: Section has assigned students. Reassign students first.";
+
+            return "Cannot delete: Section has dependencies that prevent deletion.";
         }
 
         #endregion

--- a/attendance_monitoring/Services/SectionService.cs
+++ b/attendance_monitoring/Services/SectionService.cs
@@ -1,5 +1,6 @@
 using attendance_monitoring.Classes;
 using attendance_monitoring.Exceptions;
+using attendance_monitoring.Helpers;
 using attendance_monitoring.IRepository;
 using attendance_monitoring.IServices;
 using attendance_monitoring.Models.DTO.Response;
@@ -190,7 +191,7 @@ namespace attendance_monitoring.Services
                 // Re-throw EntityNotFoundException as-is
                 throw;
             }
-            catch (DbUpdateException ex) when (IsForeignKeyViolation(ex))
+            catch (DbUpdateException ex) when (ExceptionHandlingHelper.IsForeignKeyViolation(ex))
             {
                 // Translate FK constraint violations into EntityConflictException
                 var conflictMessage = ResolveConflictMessage(ex);
@@ -202,20 +203,6 @@ namespace attendance_monitoring.Services
                 logger.LogError(ex, "An error occurred while deleting section with ID {SectionId} from repository.", id);
                 throw new EntityServiceException("Section", $"DeleteSection: {id}", "An error occurred while deleting the section", ex);
             }
-        }
-
-        /// <summary>
-        /// Determines if a DbUpdateException represents a foreign key constraint violation.
-        /// </summary>
-        private static bool IsForeignKeyViolation(DbUpdateException ex)
-        {
-            // Check for SQL Server FK constraint violation (error number 547)
-            // or PostgreSQL FK violation (SQLSTATE 23503)
-            var innerMessage = ex.InnerException?.Message?.ToLowerInvariant() ?? string.Empty;
-            return innerMessage.Contains("foreign key") ||
-                   innerMessage.Contains("constraint") ||
-                   innerMessage.Contains("23503") ||
-                   innerMessage.Contains("547");
         }
 
         /// <summary>


### PR DESCRIPTION
- improve delete err handling with depenednecy detection
- song atm: wla

----
## Summary by Gitar

- **New exception class:**
  - Added `EntityConflictException` for handling foreign key constraint violations during delete operations
- **Improved error handling:**
  - Added FK violation detection (`IsForeignKeyViolation`, `ResolveConflictType`, `ResolveConflictMessage`) in `SectionService.DeleteSectionAsync`
  - Updated `SectionController.DeleteSection` to catch and return 409 Conflict response with `ErrorResponseDto`
- **Enhanced test coverage:**
  - Added 11 new tests covering success, not-found, and FK conflict scenarios (schedules, students, enrollments)

<sub>This will update automatically on new commits.</sub>