### PR TITLE
refactor: extract interfaces for account services and create tests fo…

### DIFF
--- a/attendance.testproject/Services_Testing/AccountServiceTest.cs
+++ b/attendance.testproject/Services_Testing/AccountServiceTest.cs
@@ -1,0 +1,384 @@
+using attendance_monitoring.IServices;
+using attendance_monitoring.Models.DTO;
+using attendance_monitoring.Models.DTO.Request;
+using attendance_monitoring.Models.DTO.Response;
+using attendance_monitoring.Services;
+using attendance_monitoring.Services.Account;
+
+namespace attendance.testproject.Services_Testing;
+
+public class AccountServiceTest
+{
+    private readonly FakeRegistrationService _registrationService;
+    private readonly FakeAuthenticationService _authenticationService;
+    private readonly FakeProfileService _profileService;
+    private readonly FakeAdminService _adminService;
+    private readonly AccountService _service;
+
+    public AccountServiceTest()
+    {
+        _registrationService = new FakeRegistrationService();
+        _authenticationService = new FakeAuthenticationService();
+        _profileService = new FakeProfileService();
+        _adminService = new FakeAdminService();
+
+        _service = new AccountService(
+            _registrationService,
+            _authenticationService,
+            _profileService,
+            _adminService);
+    }
+
+    [Fact]
+    public void Constructor_NullRegistrationService_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new AccountService(null!, _authenticationService, _profileService, _adminService));
+
+        Assert.Equal("registrationService", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_NullAuthenticationService_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new AccountService(_registrationService, null!, _profileService, _adminService));
+
+        Assert.Equal("authenticationService", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_NullProfileService_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new AccountService(_registrationService, _authenticationService, null!, _adminService));
+
+        Assert.Equal("profileService", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_NullAdminService_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new AccountService(_registrationService, _authenticationService, _profileService, null!));
+
+        Assert.Equal("adminService", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task GetAllUsersAsync_ForwardsStatusToAdminService()
+    {
+        var users = new List<GetAllUsersDto> { new() { UserId = "user-1", Username = "alpha" } };
+        _adminService.GetAllUsersResult = users;
+
+        var result = await _service.GetAllUsersAsync(UserStatus.Archived);
+
+        Assert.Same(users, result);
+        Assert.Equal(UserStatus.Archived, _adminService.LastStatus);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ReturnsRegistrationResult()
+    {
+        var registerDto = new RegisterDto { Username = "user", Email = "user@test.com", Password = "secret", RepeatedPassword = "secret" };
+        var expected = new RegisterResponseDto { Success = true, Message = "ok" };
+        _registrationService.RegisterResult = expected;
+
+        var result = await _service.RegisterAsync(registerDto);
+
+        Assert.Same(expected, result);
+        Assert.Same(registerDto, _registrationService.LastRegisterDto);
+    }
+
+    [Fact]
+    public async Task LoginAsync_ReturnsAuthenticationResult()
+    {
+        var loginDto = new LoginDto { Username = "user", Password = "secret" };
+        var expected = new LoginResult
+        {
+            Username = "user",
+            Role = "Admin",
+            TokenResponse = new TokenResponseDto { AccessToken = "access", RefreshToken = "refresh" },
+        };
+        _authenticationService.LoginResult = expected;
+
+        var result = await _service.LoginAsync(loginDto);
+
+        Assert.Same(expected, result);
+        Assert.Same(loginDto, _authenticationService.LastLoginDto);
+    }
+
+    [Fact]
+    public async Task RefreshAsync_ReturnsAuthenticationResult()
+    {
+        var request = new RefreshTokenRequestDto { RefreshToken = "refresh" };
+        var expected = new TokenResponseDto { AccessToken = "access", RefreshToken = "refresh-2" };
+        _authenticationService.RefreshResult = expected;
+
+        var result = await _service.RefreshAsync(request);
+
+        Assert.Same(expected, result);
+        Assert.Same(request, _authenticationService.LastRefreshRequest);
+    }
+
+    [Fact]
+    public async Task RevokeAsync_ForwardsArgumentsToAuthenticationService()
+    {
+        var request = new RevokeTokenRequestDto { RefreshToken = "refresh" };
+        var expected = new RevokeResponseDto { Success = true, Message = "revoked" };
+        _authenticationService.RevokeResult = expected;
+
+        var result = await _service.RevokeAsync(request, "user-1");
+
+        Assert.Same(expected, result);
+        Assert.Same(request, _authenticationService.LastRevokeRequest);
+        Assert.Equal("user-1", _authenticationService.LastRevokeUserId);
+    }
+
+    [Fact]
+    public async Task LogoutAsync_ReturnsAuthenticationResult()
+    {
+        var expected = new LogoutResponseDto { Success = true, Message = "logged out" };
+        _authenticationService.LogoutResult = expected;
+
+        var result = await _service.LogoutAsync("user-1", "token");
+
+        Assert.Same(expected, result);
+        Assert.Equal("user-1", _authenticationService.LastLogoutUserId);
+        Assert.Equal("token", _authenticationService.LastLogoutAccessToken);
+    }
+
+    [Fact]
+    public async Task WebLogoutAsync_ReturnsAuthenticationResult()
+    {
+        var expected = new LogoutResponseDto { Success = true, Message = "logged out" };
+        _authenticationService.WebLogoutResult = expected;
+
+        var result = await _service.WebLogoutAsync("user-1", "token");
+
+        Assert.Same(expected, result);
+        Assert.Equal("user-1", _authenticationService.LastWebLogoutUserId);
+        Assert.Equal("token", _authenticationService.LastWebLogoutAccessToken);
+    }
+
+    [Fact]
+    public async Task BlacklistTokenAsync_ForwardsArgumentsToAuthenticationService()
+    {
+        var expiresAt = DateTime.UtcNow.AddMinutes(30);
+
+        await _service.BlacklistTokenAsync("jti-1", expiresAt);
+
+        Assert.Equal("jti-1", _authenticationService.LastBlacklistedJti);
+        Assert.Equal(expiresAt, _authenticationService.LastBlacklistedExpiresAt);
+    }
+
+    [Fact]
+    public async Task GetUserProfileAsync_ReturnsProfileResult()
+    {
+        var expected = new UserProfileResponseDto { UserId = "user-1", Username = "alpha" };
+        _profileService.GetProfileResult = expected;
+
+        var result = await _service.GetUserProfileAsync("user-1");
+
+        Assert.Same(expected, result);
+        Assert.Equal("user-1", _profileService.LastGetUserId);
+    }
+
+    [Fact]
+    public async Task UpdateUserProfileAsync_ReturnsProfileResult()
+    {
+        var request = new UpdateProfile { Firstname = "Ada" };
+        var expected = new UserProfileResponseDto { UserId = "user-1", Username = "alpha" };
+        _profileService.UpdateProfileResult = expected;
+
+        var result = await _service.UpdateUserProfileAsync("user-1", request);
+
+        Assert.Same(expected, result);
+        Assert.Equal("user-1", _profileService.LastUpdateUserId);
+        Assert.Same(request, _profileService.LastUpdateProfile);
+    }
+
+    [Fact]
+    public async Task AdminUpdateUserProfileAsync_ReturnsAdminResult()
+    {
+        var request = new AdminUpdateUser { UserId = "user-2", Firstname = "Grace" };
+        var expected = new UserProfileResponseDto { UserId = "user-2", Username = "beta" };
+        _adminService.AdminUpdateResult = expected;
+
+        var result = await _service.AdminUpdateUserProfileAsync("admin-1", request);
+
+        Assert.Same(expected, result);
+        Assert.Equal("admin-1", _adminService.LastAdminUpdateAdminId);
+        Assert.Same(request, _adminService.LastAdminUpdateUser);
+    }
+
+    [Fact]
+    public async Task AdminDeleteUserAsync_ForwardsArgumentsToAdminService()
+    {
+        await _service.AdminDeleteUserAsync("admin-1", "user-2");
+
+        Assert.Equal("admin-1", _adminService.LastDeleteAdminId);
+        Assert.Equal("user-2", _adminService.LastDeleteTargetUserId);
+    }
+
+    [Fact]
+    public async Task AdminHardDeleteUserAsync_ForwardsArgumentsToAdminService()
+    {
+        await _service.AdminHardDeleteUserAsync("admin-1", "user-2");
+
+        Assert.Equal("admin-1", _adminService.LastHardDeleteAdminId);
+        Assert.Equal("user-2", _adminService.LastHardDeleteTargetUserId);
+    }
+
+    [Fact]
+    public async Task AdminRestoreUserAsync_ForwardsArgumentsToAdminService()
+    {
+        await _service.AdminRestoreUserAsync("admin-1", "user-2");
+
+        Assert.Equal("admin-1", _adminService.LastRestoreAdminId);
+        Assert.Equal("user-2", _adminService.LastRestoreTargetUserId);
+    }
+
+    private sealed class FakeRegistrationService : IRegistrationService
+    {
+        public RegisterDto? LastRegisterDto { get; private set; }
+        public RegisterResponseDto RegisterResult { get; set; } = new();
+
+        public Task<RegisterResponseDto> RegisterAsync(RegisterDto registerDto)
+        {
+            LastRegisterDto = registerDto;
+            return Task.FromResult(RegisterResult);
+        }
+    }
+
+    private sealed class FakeAuthenticationService : IAuthenticationService
+    {
+        public LoginDto? LastLoginDto { get; private set; }
+        public RefreshTokenRequestDto? LastRefreshRequest { get; private set; }
+        public RevokeTokenRequestDto? LastRevokeRequest { get; private set; }
+        public string? LastRevokeUserId { get; private set; }
+        public string? LastLogoutUserId { get; private set; }
+        public string? LastLogoutAccessToken { get; private set; }
+        public string? LastWebLogoutUserId { get; private set; }
+        public string? LastWebLogoutAccessToken { get; private set; }
+        public string? LastBlacklistedJti { get; private set; }
+        public DateTime LastBlacklistedExpiresAt { get; private set; }
+        public LoginResult LoginResult { get; set; } = new()
+        {
+            Username = string.Empty,
+            Role = string.Empty,
+            TokenResponse = new TokenResponseDto(),
+        };
+        public TokenResponseDto RefreshResult { get; set; } = new();
+        public RevokeResponseDto RevokeResult { get; set; } = new();
+        public LogoutResponseDto LogoutResult { get; set; } = new();
+        public LogoutResponseDto WebLogoutResult { get; set; } = new();
+
+        public Task<LoginResult> LoginAsync(LoginDto loginDto)
+        {
+            LastLoginDto = loginDto;
+            return Task.FromResult(LoginResult);
+        }
+
+        public Task<TokenResponseDto> RefreshAsync(RefreshTokenRequestDto refreshTokenRequest)
+        {
+            LastRefreshRequest = refreshTokenRequest;
+            return Task.FromResult(RefreshResult);
+        }
+
+        public Task<RevokeResponseDto> RevokeAsync(RevokeTokenRequestDto revokeTokenRequest, string userId)
+        {
+            LastRevokeRequest = revokeTokenRequest;
+            LastRevokeUserId = userId;
+            return Task.FromResult(RevokeResult);
+        }
+
+        public Task<LogoutResponseDto> LogoutAsync(string userId, string? accessToken)
+        {
+            LastLogoutUserId = userId;
+            LastLogoutAccessToken = accessToken;
+            return Task.FromResult(LogoutResult);
+        }
+
+        public Task<LogoutResponseDto> WebLogoutAsync(string userId, string? accessToken)
+        {
+            LastWebLogoutUserId = userId;
+            LastWebLogoutAccessToken = accessToken;
+            return Task.FromResult(WebLogoutResult);
+        }
+
+        public Task BlacklistTokenAsync(string jti, DateTime expiresAt)
+        {
+            LastBlacklistedJti = jti;
+            LastBlacklistedExpiresAt = expiresAt;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeProfileService : IProfileService
+    {
+        public string? LastGetUserId { get; private set; }
+        public string? LastUpdateUserId { get; private set; }
+        public UpdateProfile? LastUpdateProfile { get; private set; }
+        public UserProfileResponseDto GetProfileResult { get; set; } = new();
+        public UserProfileResponseDto UpdateProfileResult { get; set; } = new();
+
+        public Task<UserProfileResponseDto> GetUserProfileAsync(string userId)
+        {
+            LastGetUserId = userId;
+            return Task.FromResult(GetProfileResult);
+        }
+
+        public Task<UserProfileResponseDto> UpdateUserProfileAsync(string userId, UpdateProfile updateProfileDto)
+        {
+            LastUpdateUserId = userId;
+            LastUpdateProfile = updateProfileDto;
+            return Task.FromResult(UpdateProfileResult);
+        }
+    }
+
+    private sealed class FakeAdminService : IAdminService
+    {
+        public UserStatus LastStatus { get; private set; }
+        public IEnumerable<GetAllUsersDto> GetAllUsersResult { get; set; } = Array.Empty<GetAllUsersDto>();
+        public string? LastAdminUpdateAdminId { get; private set; }
+        public AdminUpdateUser? LastAdminUpdateUser { get; private set; }
+        public UserProfileResponseDto AdminUpdateResult { get; set; } = new();
+        public string? LastDeleteAdminId { get; private set; }
+        public string? LastDeleteTargetUserId { get; private set; }
+        public string? LastHardDeleteAdminId { get; private set; }
+        public string? LastHardDeleteTargetUserId { get; private set; }
+        public string? LastRestoreAdminId { get; private set; }
+        public string? LastRestoreTargetUserId { get; private set; }
+
+        public Task<IEnumerable<GetAllUsersDto>> GetAllUsersAsync(UserStatus status = UserStatus.Active)
+        {
+            LastStatus = status;
+            return Task.FromResult(GetAllUsersResult);
+        }
+
+        public Task<UserProfileResponseDto> AdminUpdateUserProfileAsync(string adminId, AdminUpdateUser adminUpdateDto)
+        {
+            LastAdminUpdateAdminId = adminId;
+            LastAdminUpdateUser = adminUpdateDto;
+            return Task.FromResult(AdminUpdateResult);
+        }
+
+        public Task AdminDeleteUserAsync(string adminId, string targetUserId)
+        {
+            LastDeleteAdminId = adminId;
+            LastDeleteTargetUserId = targetUserId;
+            return Task.CompletedTask;
+        }
+
+        public Task AdminHardDeleteUserAsync(string adminId, string targetUserId)
+        {
+            LastHardDeleteAdminId = adminId;
+            LastHardDeleteTargetUserId = targetUserId;
+            return Task.CompletedTask;
+        }
+
+        public Task AdminRestoreUserAsync(string adminId, string targetUserId)
+        {
+            LastRestoreAdminId = adminId;
+            LastRestoreTargetUserId = targetUserId;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/attendance.testproject/Services_Testing/ClassroomServiceTest.cs
+++ b/attendance.testproject/Services_Testing/ClassroomServiceTest.cs
@@ -1,0 +1,516 @@
+using attendance_monitoring.Classes;
+using attendance_monitoring.Exceptions;
+using attendance_monitoring.IRepository;
+using attendance_monitoring.Models.DTO.Request;
+using attendance_monitoring.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace attendance.testproject.Services_Testing;
+
+public class ClassroomServiceTest
+{
+    private readonly Mock<IClassroomRepository> _mockClassroomRepository;
+    private readonly Mock<ILogger<ClassroomService>> _mockLogger;
+    private readonly ClassroomService _service;
+
+    public ClassroomServiceTest()
+    {
+        _mockClassroomRepository = new Mock<IClassroomRepository>();
+        _mockLogger = new Mock<ILogger<ClassroomService>>();
+        _service = new ClassroomService(_mockClassroomRepository.Object, _mockLogger.Object);
+    }
+
+    [Fact]
+    public void Constructor_NullRepository_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new ClassroomService(null!, _mockLogger.Object));
+
+        Assert.Equal("classroomRepository", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new ClassroomService(_mockClassroomRepository.Object, null!));
+
+        Assert.Equal("logger", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task GetAllClassroomsAsync_ReturnsMaterializedClassrooms()
+    {
+        var classrooms = new List<Classroom>
+        {
+            new() { Id = 1, Name = "Room A" },
+            new() { Id = 2, Name = "Room B" },
+        };
+
+        _mockClassroomRepository
+            .Setup(repository => repository.GetAllClassroomsAsync())
+            .ReturnsAsync(classrooms);
+
+        var result = await _service.GetAllClassroomsAsync();
+
+        var materialized = Assert.IsType<List<Classroom>>(result);
+        Assert.Collection(materialized,
+            classroom => Assert.Equal("Room A", classroom.Name),
+            classroom => Assert.Equal("Room B", classroom.Name));
+    }
+
+    [Fact]
+    public async Task GetAllClassroomsAsync_WrapsUnexpectedFailures()
+    {
+        var expectedException = new InvalidOperationException("Lookup failed");
+        _mockClassroomRepository
+            .Setup(repository => repository.GetAllClassroomsAsync())
+            .ThrowsAsync(expectedException);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.GetAllClassroomsAsync());
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal("GetAllClassrooms", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task GetClassroomByIdAsync_ReturnsClassroom_WhenFound()
+    {
+        var classroom = new Classroom { Id = 7, Name = "Room 207" };
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByIdAsync(7))
+            .ReturnsAsync(classroom);
+
+        var result = await _service.GetClassroomByIdAsync(7);
+
+        Assert.Same(classroom, result);
+    }
+
+    [Fact]
+    public async Task GetClassroomByIdAsync_ThrowsEntityNotFoundException_WhenMissing()
+    {
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByIdAsync(7))
+            .ReturnsAsync((Classroom?)null);
+
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<int>>(() => _service.GetClassroomByIdAsync(7));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal(7, exception.Key);
+    }
+
+    [Fact]
+    public async Task GetClassroomByIdAsync_WrapsUnexpectedFailures()
+    {
+        var expectedException = new InvalidOperationException("Lookup failed");
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByIdAsync(7))
+            .ThrowsAsync(expectedException);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.GetClassroomByIdAsync(7));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal("GetClassroomById: 7", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task CreateClassroomAsync_BlankName_ThrowsValidationException(string? name)
+    {
+        var createClassroom = new CreateClassroom { Name = name! };
+
+        var exception = await Assert.ThrowsAsync<ValidationException>(() => _service.CreateClassroomAsync(createClassroom));
+
+        Assert.Equal("Classroom name is required", exception.Message);
+    }
+
+    [Fact]
+    public async Task CreateClassroomAsync_DuplicateNamePreCheck_ThrowsEntityAlreadyExistsException()
+    {
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByNameAsync("Room 101"))
+            .ReturnsAsync(new Classroom { Id = 1, Name = "Room 101" });
+
+        var exception = await Assert.ThrowsAsync<EntityAlreadyExistsException<string>>(
+            () => _service.CreateClassroomAsync(new CreateClassroom { Name = "Room 101" }));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal("Name", exception.IdentifierPropertyName);
+        Assert.Equal("Room 101", exception.EntityIdentifier);
+    }
+
+    [Fact]
+    public async Task CreateClassroomAsync_ValidInput_CreatesClassroom()
+    {
+        Classroom? capturedClassroom = null;
+        var createdClassroom = new Classroom { Id = 3, Name = "Lab 1" };
+
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByNameAsync("Lab 1"))
+            .ReturnsAsync((Classroom?)null);
+        _mockClassroomRepository
+            .Setup(repository => repository.CreateClassroom(It.IsAny<Classroom>()))
+            .Callback<Classroom>(classroom => capturedClassroom = classroom)
+            .ReturnsAsync(createdClassroom);
+        _mockClassroomRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        var result = await _service.CreateClassroomAsync(new CreateClassroom { Name = "Lab 1" });
+
+        Assert.Same(createdClassroom, result);
+        Assert.NotNull(capturedClassroom);
+        Assert.Equal("Lab 1", capturedClassroom.Name);
+        _mockClassroomRepository.Verify(repository => repository.CreateClassroom(It.IsAny<Classroom>()), Times.Once);
+        _mockClassroomRepository.Verify(repository => repository.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateClassroomAsync_UniqueConstraintViolation_ThrowsEntityAlreadyExistsException()
+    {
+        var dbUpdateException = new DbUpdateException(
+            "Duplicate",
+            new Exception("Cannot insert duplicate key row with unique index 'IX_Classrooms_Name'"));
+
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByNameAsync("Lab 1"))
+            .ReturnsAsync((Classroom?)null);
+        _mockClassroomRepository
+            .Setup(repository => repository.CreateClassroom(It.IsAny<Classroom>()))
+            .ThrowsAsync(dbUpdateException);
+
+        var exception = await Assert.ThrowsAsync<EntityAlreadyExistsException<string>>(
+            () => _service.CreateClassroomAsync(new CreateClassroom { Name = "Lab 1" }));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal("Name", exception.IdentifierPropertyName);
+        Assert.Equal("Lab 1", exception.EntityIdentifier);
+    }
+
+    [Fact]
+    public async Task CreateClassroomAsync_WrapsUnexpectedFailures()
+    {
+        var expectedException = new InvalidOperationException("Create failed");
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByNameAsync("Lab 1"))
+            .ThrowsAsync(expectedException);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.CreateClassroomAsync(new CreateClassroom { Name = "Lab 1" }));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal("CreateClassroom", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task UpdateClassroomAsync_NotFound_ThrowsEntityNotFoundException()
+    {
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByIdAsync(8))
+            .ReturnsAsync((Classroom?)null);
+
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<int>>(
+            () => _service.UpdateClassroomAsync(8, new UpdateClassroom { Name = "Updated" }));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal(8, exception.Key);
+    }
+
+    [Fact]
+    public async Task UpdateClassroomAsync_ValidInput_UpdatesClassroom()
+    {
+        var existingClassroom = new Classroom { Id = 8, Name = "Old" };
+        Classroom? updatedEntity = null;
+
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByIdAsync(8))
+            .ReturnsAsync(existingClassroom);
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByNameAsync("New"))
+            .ReturnsAsync((Classroom?)null);
+        _mockClassroomRepository
+            .Setup(repository => repository.UpdateClassroomAsync(It.IsAny<Classroom>()))
+            .Callback<Classroom>(classroom => updatedEntity = classroom)
+            .ReturnsAsync((Classroom classroom) => classroom);
+        _mockClassroomRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        var result = await _service.UpdateClassroomAsync(8, new UpdateClassroom { Name = "New" });
+
+        Assert.Equal("New", result.Name);
+        Assert.NotNull(updatedEntity);
+        Assert.Equal("New", updatedEntity.Name);
+        _mockClassroomRepository.Verify(repository => repository.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateClassroomAsync_EmptyName_LeavesNameUnchanged()
+    {
+        var existingClassroom = new Classroom { Id = 8, Name = "Old" };
+
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByIdAsync(8))
+            .ReturnsAsync(existingClassroom);
+        _mockClassroomRepository
+            .Setup(repository => repository.UpdateClassroomAsync(It.IsAny<Classroom>()))
+            .ReturnsAsync((Classroom classroom) => classroom);
+        _mockClassroomRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        var result = await _service.UpdateClassroomAsync(8, new UpdateClassroom { Name = string.Empty });
+
+        Assert.Equal("Old", result.Name);
+        _mockClassroomRepository.Verify(repository => repository.GetClassroomByNameAsync(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateClassroomAsync_DuplicateName_ThrowsEntityAlreadyExistsException()
+    {
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByIdAsync(8))
+            .ReturnsAsync(new Classroom { Id = 8, Name = "Old" });
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByNameAsync("Taken"))
+            .ReturnsAsync(new Classroom { Id = 11, Name = "Taken" });
+
+        var exception = await Assert.ThrowsAsync<EntityAlreadyExistsException<string>>(
+            () => _service.UpdateClassroomAsync(8, new UpdateClassroom { Name = "Taken" }));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal("Name", exception.IdentifierPropertyName);
+        Assert.Equal("Taken", exception.EntityIdentifier);
+    }
+
+    [Fact]
+    public async Task UpdateClassroomAsync_UniqueConstraintViolation_ThrowsEntityAlreadyExistsException()
+    {
+        var dbUpdateException = new DbUpdateException(
+            "Duplicate",
+            new Exception("duplicate key value violates unique constraint \"IX_Classrooms_Name\""));
+
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByIdAsync(8))
+            .ReturnsAsync(new Classroom { Id = 8, Name = "Old" });
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByNameAsync("New"))
+            .ReturnsAsync((Classroom?)null);
+        _mockClassroomRepository
+            .Setup(repository => repository.UpdateClassroomAsync(It.IsAny<Classroom>()))
+            .ThrowsAsync(dbUpdateException);
+
+        var exception = await Assert.ThrowsAsync<EntityAlreadyExistsException<string>>(
+            () => _service.UpdateClassroomAsync(8, new UpdateClassroom { Name = "New" }));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal("Name", exception.IdentifierPropertyName);
+        Assert.Equal("New", exception.EntityIdentifier);
+    }
+
+    [Fact]
+    public async Task UpdateClassroomAsync_NoRowsAffected_ThrowsEntityServiceException()
+    {
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByIdAsync(8))
+            .ReturnsAsync(new Classroom { Id = 8, Name = "Old" });
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByNameAsync("New"))
+            .ReturnsAsync((Classroom?)null);
+        _mockClassroomRepository
+            .Setup(repository => repository.UpdateClassroomAsync(It.IsAny<Classroom>()))
+            .ReturnsAsync((Classroom classroom) => classroom);
+        _mockClassroomRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ReturnsAsync(0);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.UpdateClassroomAsync(8, new UpdateClassroom { Name = "New" }));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal("UpdateClassroom: 8", exception.Operation);
+        Assert.Contains("updated by another process", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UpdateClassroomAsync_WrapsUnexpectedFailures()
+    {
+        var expectedException = new InvalidOperationException("Update failed");
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByIdAsync(8))
+            .ThrowsAsync(expectedException);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.UpdateClassroomAsync(8, new UpdateClassroom { Name = "New" }));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal("UpdateClassroom: 8", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task DeleteClassroomAsync_NotFound_ThrowsEntityNotFoundException()
+    {
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByIdAsync(5))
+            .ReturnsAsync((Classroom?)null);
+
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<int>>(() => _service.DeleteClassroomAsync(5));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal(5, exception.Key);
+    }
+
+    [Fact]
+    public async Task DeleteClassroomAsync_Success_DeletesClassroom()
+    {
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByIdAsync(5))
+            .ReturnsAsync(new Classroom { Id = 5, Name = "Room 5" });
+        _mockClassroomRepository
+            .Setup(repository => repository.DeleteClassroomAsync(5))
+            .ReturnsAsync(true);
+        _mockClassroomRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        await _service.DeleteClassroomAsync(5);
+
+        _mockClassroomRepository.Verify(repository => repository.DeleteClassroomAsync(5), Times.Once);
+        _mockClassroomRepository.Verify(repository => repository.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteClassroomAsync_DeleteReturnsFalse_ThrowsEntityServiceException()
+    {
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByIdAsync(5))
+            .ReturnsAsync(new Classroom { Id = 5, Name = "Room 5" });
+        _mockClassroomRepository
+            .Setup(repository => repository.DeleteClassroomAsync(5))
+            .ReturnsAsync(false);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteClassroomAsync(5));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal("DeleteClassroom: 5", exception.Operation);
+    }
+
+    [Fact]
+    public async Task DeleteClassroomAsync_NoRowsAffected_ThrowsEntityServiceException()
+    {
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByIdAsync(5))
+            .ReturnsAsync(new Classroom { Id = 5, Name = "Room 5" });
+        _mockClassroomRepository
+            .Setup(repository => repository.DeleteClassroomAsync(5))
+            .ReturnsAsync(true);
+        _mockClassroomRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ReturnsAsync(0);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteClassroomAsync(5));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal("DeleteClassroom: 5", exception.Operation);
+        Assert.Contains("deleted by another process", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("The DELETE statement conflicted with the REFERENCE constraint \"FK_Sessions_Classrooms_ActualRoomId\"", "sessions")]
+    [InlineData("The DELETE statement conflicted with the REFERENCE constraint \"FK_Schedules_Classrooms\"", "schedules")]
+    [InlineData("23503: update or delete on table \"Classrooms\" violates foreign key constraint \"FK_Unknown\"", "dependencies")]
+    public async Task DeleteClassroomAsync_ForeignKeyViolation_ThrowsEntityConflictException(string innerMessage, string expectedConflictType)
+    {
+        var dbUpdateException = new DbUpdateException("Delete failed", new Exception(innerMessage));
+
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByIdAsync(5))
+            .ReturnsAsync(new Classroom { Id = 5, Name = "Room 5" });
+        _mockClassroomRepository
+            .Setup(repository => repository.DeleteClassroomAsync(5))
+            .ReturnsAsync(true);
+        _mockClassroomRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ThrowsAsync(dbUpdateException);
+
+        var exception = await Assert.ThrowsAsync<EntityConflictException>(() => _service.DeleteClassroomAsync(5));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal(expectedConflictType, exception.ConflictType);
+    }
+
+    [Fact]
+    public async Task DeleteClassroomAsync_WrapsUnexpectedFailures()
+    {
+        var expectedException = new InvalidOperationException("Delete failed");
+        _mockClassroomRepository
+            .Setup(repository => repository.GetClassroomByIdAsync(5))
+            .ThrowsAsync(expectedException);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteClassroomAsync(5));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal("DeleteClassroom: 5", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task HasSchedulesInClassroomAsync_ReturnsRepositoryResult()
+    {
+        _mockClassroomRepository
+            .Setup(repository => repository.HasSchedulesInClassroomAsync(3))
+            .ReturnsAsync(true);
+
+        var result = await _service.HasSchedulesInClassroomAsync(3);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task HasSchedulesInClassroomAsync_WrapsUnexpectedFailures()
+    {
+        var expectedException = new InvalidOperationException("Lookup failed");
+        _mockClassroomRepository
+            .Setup(repository => repository.HasSchedulesInClassroomAsync(3))
+            .ThrowsAsync(expectedException);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.HasSchedulesInClassroomAsync(3));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal("HasSchedulesInClassroom: 3", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task HasSessionsInClassroomAsync_ReturnsRepositoryResult()
+    {
+        _mockClassroomRepository
+            .Setup(repository => repository.HasSessionsInClassroomAsync(3))
+            .ReturnsAsync(true);
+
+        var result = await _service.HasSessionsInClassroomAsync(3);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task HasSessionsInClassroomAsync_WrapsUnexpectedFailures()
+    {
+        var expectedException = new InvalidOperationException("Lookup failed");
+        _mockClassroomRepository
+            .Setup(repository => repository.HasSessionsInClassroomAsync(3))
+            .ThrowsAsync(expectedException);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.HasSessionsInClassroomAsync(3));
+
+        Assert.Equal("Classroom", exception.EntityName);
+        Assert.Equal("HasSessionsInClassroom: 3", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+}

--- a/attendance.testproject/Services_Testing/CourseServiceTest.cs
+++ b/attendance.testproject/Services_Testing/CourseServiceTest.cs
@@ -1,0 +1,462 @@
+using System.Security.Claims;
+using attendance_monitoring.Classes;
+using attendance_monitoring.Exceptions;
+using attendance_monitoring.IRepository;
+using attendance_monitoring.IServices;
+using attendance_monitoring.Models.DTO.Request;
+using attendance_monitoring.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace attendance.testproject.Services_Testing;
+
+public class CourseServiceTest
+{
+    private readonly Mock<ICourseRepository> _mockCourseRepository;
+    private readonly Mock<IUserContextService> _mockUserContextService;
+    private readonly Mock<ILogger<CourseService>> _mockLogger;
+    private readonly CourseService _service;
+    private readonly ClaimsPrincipal _testUserPrincipal;
+
+    public CourseServiceTest()
+    {
+        _mockCourseRepository = new Mock<ICourseRepository>();
+        _mockUserContextService = new Mock<IUserContextService>();
+        _mockLogger = new Mock<ILogger<CourseService>>();
+        _service = new CourseService(_mockCourseRepository.Object, _mockUserContextService.Object, _mockLogger.Object);
+
+        _testUserPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, "user-1"),
+            new Claim(ClaimTypes.Name, "Test User"),
+        }, "TestAuth"));
+    }
+
+    [Fact]
+    public void Constructor_NullRepository_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new CourseService(null!, _mockUserContextService.Object, _mockLogger.Object));
+
+        Assert.Equal("courseRepository", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_NullUserContextService_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new CourseService(_mockCourseRepository.Object, null!, _mockLogger.Object));
+
+        Assert.Equal("userContextService", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new CourseService(_mockCourseRepository.Object, _mockUserContextService.Object, null!));
+
+        Assert.Equal("logger", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task GetAllCoursesAsync_ReturnsMaterializedCourses()
+    {
+        _mockCourseRepository
+            .Setup(repository => repository.GetAllCoursesAsync())
+            .ReturnsAsync(new List<Course>
+            {
+                new() { Id = 1, Name = "Math" },
+                new() { Id = 2, Name = "Science" },
+            });
+
+        var result = await _service.GetAllCoursesAsync();
+
+        var materialized = Assert.IsType<List<Course>>(result);
+        Assert.Collection(materialized,
+            course => Assert.Equal("Math", course.Name),
+            course => Assert.Equal("Science", course.Name));
+    }
+
+    [Fact]
+    public async Task GetAllCoursesAsync_WrapsUnexpectedFailures()
+    {
+        var expectedException = new InvalidOperationException("Lookup failed");
+        _mockCourseRepository
+            .Setup(repository => repository.GetAllCoursesAsync())
+            .ThrowsAsync(expectedException);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.GetAllCoursesAsync());
+
+        Assert.Equal("Course", exception.EntityName);
+        Assert.Equal("GetAllCourses", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task GetCourseByIdAsync_ReturnsCourse_WhenFound()
+    {
+        var course = new Course { Id = 4, Name = "Physics" };
+        _mockCourseRepository
+            .Setup(repository => repository.GetCourseByIdAsync(4))
+            .ReturnsAsync(course);
+
+        var result = await _service.GetCourseByIdAsync(4);
+
+        Assert.Same(course, result);
+    }
+
+    [Fact]
+    public async Task GetCourseByIdAsync_ThrowsEntityNotFoundException_WhenMissing()
+    {
+        _mockCourseRepository
+            .Setup(repository => repository.GetCourseByIdAsync(4))
+            .ReturnsAsync((Course?)null);
+
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<int>>(() => _service.GetCourseByIdAsync(4));
+
+        Assert.Equal("Course", exception.EntityName);
+        Assert.Equal(4, exception.Key);
+    }
+
+    [Fact]
+    public async Task GetCourseByIdAsync_WrapsUnexpectedFailures()
+    {
+        var expectedException = new InvalidOperationException("Lookup failed");
+        _mockCourseRepository
+            .Setup(repository => repository.GetCourseByIdAsync(4))
+            .ThrowsAsync(expectedException);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.GetCourseByIdAsync(4));
+
+        Assert.Equal("Course", exception.EntityName);
+        Assert.Equal("GetCourseById: 4", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task CreateCourseAsync_BlankName_ThrowsEntityServiceException(string? name)
+    {
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.CreateCourseAsync(new CreateCourse { Name = name! }, _testUserPrincipal));
+
+        Assert.Equal("Course", exception.EntityName);
+        Assert.Equal("CreateCourse", exception.Operation);
+        Assert.Contains("Course name is required", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task CreateCourseAsync_MissingUserId_ThrowsEntityServiceException()
+    {
+        _mockUserContextService
+            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .ReturnsAsync((string?)null);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.CreateCourseAsync(new CreateCourse { Name = "Physics" }, _testUserPrincipal));
+
+        Assert.Equal("Course", exception.EntityName);
+        Assert.Equal("CreateCourse", exception.Operation);
+        Assert.Contains("User ID not found", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task CreateCourseAsync_ValidInput_CreatesCourse()
+    {
+        Course? capturedCourse = null;
+        var createdCourse = new Course { Id = 10, Name = "Physics" };
+
+        _mockUserContextService
+            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .ReturnsAsync("user-1");
+        _mockCourseRepository
+            .Setup(repository => repository.CreateCourse(It.IsAny<Course>()))
+            .Callback<Course>(course => capturedCourse = course)
+            .ReturnsAsync(createdCourse);
+        _mockCourseRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        var result = await _service.CreateCourseAsync(new CreateCourse { Name = "Physics" }, _testUserPrincipal);
+
+        Assert.Same(createdCourse, result);
+        Assert.NotNull(capturedCourse);
+        Assert.Equal("Physics", capturedCourse.Name);
+        _mockCourseRepository.Verify(repository => repository.CreateCourse(It.IsAny<Course>()), Times.Once);
+        _mockCourseRepository.Verify(repository => repository.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateCourseAsync_WrapsUnexpectedFailures()
+    {
+        var expectedException = new InvalidOperationException("Create failed");
+        _mockUserContextService
+            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .ReturnsAsync("user-1");
+        _mockCourseRepository
+            .Setup(repository => repository.CreateCourse(It.IsAny<Course>()))
+            .ThrowsAsync(expectedException);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.CreateCourseAsync(new CreateCourse { Name = "Physics" }, _testUserPrincipal));
+
+        Assert.Equal("Course", exception.EntityName);
+        Assert.Equal("CreateCourse", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task UpdateCourseAsync_NullUpdateDto_ThrowsEntityServiceException()
+    {
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.UpdateCourseAsync(4, null!, _testUserPrincipal));
+
+        Assert.Equal("Course", exception.EntityName);
+        Assert.Equal("UpdateCourse: 4", exception.Operation);
+        Assert.Contains("required", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UpdateCourseAsync_MissingUserId_ThrowsEntityServiceException()
+    {
+        _mockUserContextService
+            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .ReturnsAsync(string.Empty);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.UpdateCourseAsync(4, new UpdateCourse { Name = "New" }, _testUserPrincipal));
+
+        Assert.Equal("Course", exception.EntityName);
+        Assert.Equal("UpdateCourse: 4", exception.Operation);
+        Assert.Contains("User ID not found", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UpdateCourseAsync_NotFound_ThrowsEntityNotFoundException()
+    {
+        _mockUserContextService
+            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .ReturnsAsync("user-1");
+        _mockCourseRepository
+            .Setup(repository => repository.GetCourseByIdAsync(4))
+            .ReturnsAsync((Course?)null);
+
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<int>>(
+            () => _service.UpdateCourseAsync(4, new UpdateCourse { Name = "New" }, _testUserPrincipal));
+
+        Assert.Equal("Course", exception.EntityName);
+        Assert.Equal(4, exception.Key);
+    }
+
+    [Fact]
+    public async Task UpdateCourseAsync_ValidInput_UpdatesCourse()
+    {
+        var existingCourse = new Course { Id = 4, Name = "Old" };
+
+        _mockUserContextService
+            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .ReturnsAsync("user-1");
+        _mockCourseRepository
+            .Setup(repository => repository.GetCourseByIdAsync(4))
+            .ReturnsAsync(existingCourse);
+        _mockCourseRepository
+            .Setup(repository => repository.UpdateCourseAsync(It.IsAny<Course>()))
+            .ReturnsAsync((Course course) => course);
+        _mockCourseRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        var result = await _service.UpdateCourseAsync(4, new UpdateCourse { Name = "New" }, _testUserPrincipal);
+
+        Assert.Equal("New", result.Name);
+        _mockCourseRepository.Verify(repository => repository.UpdateCourseAsync(It.IsAny<Course>()), Times.Once);
+        _mockCourseRepository.Verify(repository => repository.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateCourseAsync_EmptyName_LeavesCourseNameUnchanged()
+    {
+        var existingCourse = new Course { Id = 4, Name = "Old" };
+
+        _mockUserContextService
+            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .ReturnsAsync("user-1");
+        _mockCourseRepository
+            .Setup(repository => repository.GetCourseByIdAsync(4))
+            .ReturnsAsync(existingCourse);
+        _mockCourseRepository
+            .Setup(repository => repository.UpdateCourseAsync(It.IsAny<Course>()))
+            .ReturnsAsync((Course course) => course);
+        _mockCourseRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        var result = await _service.UpdateCourseAsync(4, new UpdateCourse { Name = string.Empty }, _testUserPrincipal);
+
+        Assert.Equal("Old", result.Name);
+    }
+
+    [Fact]
+    public async Task UpdateCourseAsync_WrapsUnexpectedFailures()
+    {
+        var expectedException = new InvalidOperationException("Update failed");
+        _mockUserContextService
+            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .ReturnsAsync("user-1");
+        _mockCourseRepository
+            .Setup(repository => repository.GetCourseByIdAsync(4))
+            .ThrowsAsync(expectedException);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.UpdateCourseAsync(4, new UpdateCourse { Name = "New" }, _testUserPrincipal));
+
+        Assert.Equal("Course", exception.EntityName);
+        Assert.Equal("UpdateCourse: 4", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task DeleteCourseAsync_MissingUserId_ThrowsEntityServiceException()
+    {
+        _mockUserContextService
+            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .ReturnsAsync((string?)null);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteCourseAsync(9, _testUserPrincipal));
+
+        Assert.Equal("Course", exception.EntityName);
+        Assert.Equal("DeleteCourse: 9", exception.Operation);
+        Assert.Contains("User ID not found", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DeleteCourseAsync_NotFound_ThrowsEntityNotFoundException()
+    {
+        _mockUserContextService
+            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .ReturnsAsync("user-1");
+        _mockCourseRepository
+            .Setup(repository => repository.GetCourseByIdAsync(9))
+            .ReturnsAsync((Course?)null);
+
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<int>>(() => _service.DeleteCourseAsync(9, _testUserPrincipal));
+
+        Assert.Equal("Course", exception.EntityName);
+        Assert.Equal(9, exception.Key);
+    }
+
+    [Fact]
+    public async Task DeleteCourseAsync_Success_DeletesCourse()
+    {
+        _mockUserContextService
+            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .ReturnsAsync("user-1");
+        _mockCourseRepository
+            .Setup(repository => repository.GetCourseByIdAsync(9))
+            .ReturnsAsync(new Course { Id = 9, Name = "Biology" });
+        _mockCourseRepository
+            .Setup(repository => repository.DeleteCourseAsync(9))
+            .ReturnsAsync(true);
+        _mockCourseRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        await _service.DeleteCourseAsync(9, _testUserPrincipal);
+
+        _mockCourseRepository.Verify(repository => repository.DeleteCourseAsync(9), Times.Once);
+        _mockCourseRepository.Verify(repository => repository.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteCourseAsync_DeleteReturnsFalse_ThrowsEntityServiceException()
+    {
+        _mockUserContextService
+            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .ReturnsAsync("user-1");
+        _mockCourseRepository
+            .Setup(repository => repository.GetCourseByIdAsync(9))
+            .ReturnsAsync(new Course { Id = 9, Name = "Biology" });
+        _mockCourseRepository
+            .Setup(repository => repository.DeleteCourseAsync(9))
+            .ReturnsAsync(false);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteCourseAsync(9, _testUserPrincipal));
+
+        Assert.Equal("Course", exception.EntityName);
+        Assert.Equal("DeleteCourse: 9", exception.Operation);
+        Assert.Contains("Failed to delete course", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("The DELETE statement conflicted with the REFERENCE constraint \"FK_Sections_Courses\"", "sections assigned")]
+    [InlineData("23503: update or delete on table \"Courses\" violates foreign key constraint \"FK_Unknown\"", "dependencies that prevent deletion")]
+    public async Task DeleteCourseAsync_ForeignKeyViolation_ThrowsEntityConflictException(string innerMessage, string expectedMessagePart)
+    {
+        var dbUpdateException = new DbUpdateException("Delete failed", new Exception(innerMessage));
+
+        _mockUserContextService
+            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .ReturnsAsync("user-1");
+        _mockCourseRepository
+            .Setup(repository => repository.GetCourseByIdAsync(9))
+            .ReturnsAsync(new Course { Id = 9, Name = "Biology" });
+        _mockCourseRepository
+            .Setup(repository => repository.DeleteCourseAsync(9))
+            .ReturnsAsync(true);
+        _mockCourseRepository
+            .Setup(repository => repository.SaveChangesAsync())
+            .ThrowsAsync(dbUpdateException);
+
+        var exception = await Assert.ThrowsAsync<EntityConflictException>(() => _service.DeleteCourseAsync(9, _testUserPrincipal));
+
+        Assert.Equal("Course", exception.EntityName);
+        Assert.Equal("sections", exception.ConflictType);
+        Assert.Contains(expectedMessagePart, exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task DeleteCourseAsync_WrapsUnexpectedFailures()
+    {
+        var expectedException = new InvalidOperationException("Delete failed");
+        _mockUserContextService
+            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .ReturnsAsync("user-1");
+        _mockCourseRepository
+            .Setup(repository => repository.GetCourseByIdAsync(9))
+            .ThrowsAsync(expectedException);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteCourseAsync(9, _testUserPrincipal));
+
+        Assert.Equal("Course", exception.EntityName);
+        Assert.Equal("DeleteCourse: 9", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task HasSectionsInCourseAsync_ReturnsRepositoryResult()
+    {
+        _mockCourseRepository
+            .Setup(repository => repository.HasSectionsInCourseAsync(2))
+            .ReturnsAsync(true);
+
+        var result = await _service.HasSectionsInCourseAsync(2);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task HasSectionsInCourseAsync_WrapsUnexpectedFailures()
+    {
+        var expectedException = new InvalidOperationException("Lookup failed");
+        _mockCourseRepository
+            .Setup(repository => repository.HasSectionsInCourseAsync(2))
+            .ThrowsAsync(expectedException);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.HasSectionsInCourseAsync(2));
+
+        Assert.Equal("Course", exception.EntityName);
+        Assert.Equal("HasSectionsInCourse: 2", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+}

--- a/attendance_monitoring/Extensions/ServiceCollectionExtensions/DependencyInjectionExtensions.cs
+++ b/attendance_monitoring/Extensions/ServiceCollectionExtensions/DependencyInjectionExtensions.cs
@@ -68,14 +68,14 @@ public static class DependencyInjectionExtensions
         services.AddScoped<IInstructorService, InstructorService>();
         services.AddScoped<IRefreshTokenService, RefreshTokenService>();
         services.AddScoped<IAccountService>(sp => new AccountService(
-            sp.GetRequiredService<RegistrationService>(),
-            sp.GetRequiredService<AuthenticationService>(),
-            sp.GetRequiredService<ProfileService>(),
-            sp.GetRequiredService<AdminService>()));
-        services.AddScoped<RegistrationService>();
-        services.AddScoped<AuthenticationService>();
-        services.AddScoped<ProfileService>();
-        services.AddScoped<AdminService>();
+            sp.GetRequiredService<IRegistrationService>(),
+            sp.GetRequiredService<IAuthenticationService>(),
+            sp.GetRequiredService<IProfileService>(),
+            sp.GetRequiredService<IAdminService>()));
+        services.AddScoped<IRegistrationService, RegistrationService>();
+        services.AddScoped<IAuthenticationService, AuthenticationService>();
+        services.AddScoped<IProfileService, ProfileService>();
+        services.AddScoped<IAdminService, AdminService>();
         services.AddScoped<IUserFactory, attendance_monitoring.Classes.Factory.UserFactory>();
         services.AddScoped<ISectionService, SectionService>();
         services.AddScoped<ICourseService, CourseService>();

--- a/attendance_monitoring/Services/Account/AdminService.cs
+++ b/attendance_monitoring/Services/Account/AdminService.cs
@@ -14,19 +14,19 @@ namespace attendance_monitoring.Services.Account;
 /// Focused unit responsible for admin operations on user accounts.
 /// Handles user listing, admin profile updates, soft/hard deletes, and restores.
 /// </summary>
-internal sealed class AdminService
+internal sealed class AdminService : IAdminService
 {
     private readonly ApplicationDbContext _context;
     private readonly IAccountRepository _accountRepository;
     private readonly ISectionRepository _sectionRepository;
-    private readonly ProfileService _profileService;
+    private readonly IProfileService _profileService;
     private readonly ILogger<AdminService> _logger;
 
     public AdminService(
         ApplicationDbContext context,
         IAccountRepository accountRepository,
         ISectionRepository sectionRepository,
-        ProfileService profileService,
+        IProfileService profileService,
         ILogger<AdminService> logger)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));

--- a/attendance_monitoring/Services/Account/AuthenticationService.cs
+++ b/attendance_monitoring/Services/Account/AuthenticationService.cs
@@ -21,7 +21,7 @@ namespace attendance_monitoring.Services.Account;
 /// Focused unit responsible for authentication and token management.
 /// Handles login, token refresh/revoke/logout, JWT generation, and token blacklisting.
 /// </summary>
-internal sealed class AuthenticationService
+internal sealed class AuthenticationService : IAuthenticationService
 {
     private readonly IConfiguration _configuration;
     private readonly ApplicationDbContext _context;

--- a/attendance_monitoring/Services/Account/IAdminService.cs
+++ b/attendance_monitoring/Services/Account/IAdminService.cs
@@ -1,0 +1,13 @@
+using attendance_monitoring.Models.DTO.Request;
+using attendance_monitoring.Models.DTO.Response;
+
+namespace attendance_monitoring.Services.Account;
+
+internal interface IAdminService
+{
+    Task<IEnumerable<GetAllUsersDto>> GetAllUsersAsync(UserStatus status = UserStatus.Active);
+    Task<UserProfileResponseDto> AdminUpdateUserProfileAsync(string adminId, AdminUpdateUser adminUpdateDto);
+    Task AdminDeleteUserAsync(string adminId, string targetUserId);
+    Task AdminHardDeleteUserAsync(string adminId, string targetUserId);
+    Task AdminRestoreUserAsync(string adminId, string targetUserId);
+}

--- a/attendance_monitoring/Services/Account/IAuthenticationService.cs
+++ b/attendance_monitoring/Services/Account/IAuthenticationService.cs
@@ -1,0 +1,15 @@
+using attendance_monitoring.IServices;
+using attendance_monitoring.Models.DTO;
+using attendance_monitoring.Models.DTO.Response;
+
+namespace attendance_monitoring.Services.Account;
+
+internal interface IAuthenticationService
+{
+    Task<LoginResult> LoginAsync(LoginDto loginDto);
+    Task<TokenResponseDto> RefreshAsync(RefreshTokenRequestDto refreshTokenRequest);
+    Task<RevokeResponseDto> RevokeAsync(RevokeTokenRequestDto revokeTokenRequest, string userId);
+    Task<LogoutResponseDto> LogoutAsync(string userId, string? accessToken);
+    Task<LogoutResponseDto> WebLogoutAsync(string userId, string? accessToken);
+    Task BlacklistTokenAsync(string jti, DateTime expiresAt);
+}

--- a/attendance_monitoring/Services/Account/IProfileService.cs
+++ b/attendance_monitoring/Services/Account/IProfileService.cs
@@ -1,0 +1,10 @@
+using attendance_monitoring.Models.DTO.Request;
+using attendance_monitoring.Models.DTO.Response;
+
+namespace attendance_monitoring.Services.Account;
+
+internal interface IProfileService
+{
+    Task<UserProfileResponseDto> GetUserProfileAsync(string userId);
+    Task<UserProfileResponseDto> UpdateUserProfileAsync(string userId, UpdateProfile updateProfileDto);
+}

--- a/attendance_monitoring/Services/Account/IRegistrationService.cs
+++ b/attendance_monitoring/Services/Account/IRegistrationService.cs
@@ -1,0 +1,9 @@
+using attendance_monitoring.Models.DTO;
+using attendance_monitoring.Models.DTO.Response;
+
+namespace attendance_monitoring.Services.Account;
+
+internal interface IRegistrationService
+{
+    Task<RegisterResponseDto> RegisterAsync(RegisterDto registerDto);
+}

--- a/attendance_monitoring/Services/Account/ProfileService.cs
+++ b/attendance_monitoring/Services/Account/ProfileService.cs
@@ -14,7 +14,7 @@ namespace attendance_monitoring.Services.Account;
 /// Focused unit responsible for user profile operations.
 /// Handles profile retrieval and self-service profile updates.
 /// </summary>
-internal sealed class ProfileService
+internal sealed class ProfileService : IProfileService
 {
     private readonly ApplicationDbContext _context;
     private readonly IAccountRepository _accountRepository;

--- a/attendance_monitoring/Services/Account/RegistrationService.cs
+++ b/attendance_monitoring/Services/Account/RegistrationService.cs
@@ -13,7 +13,7 @@ namespace attendance_monitoring.Services.Account;
 /// Focused unit responsible for user registration operations.
 /// Handles validation, role assignment, and user creation.
 /// </summary>
-internal sealed class RegistrationService
+internal sealed class RegistrationService : IRegistrationService
 {
     private readonly IAccountRepository _accountRepository;
     private readonly ISectionRepository _sectionRepository;

--- a/attendance_monitoring/Services/AccountService.cs
+++ b/attendance_monitoring/Services/AccountService.cs
@@ -12,16 +12,16 @@ namespace attendance_monitoring.Services;
 /// </summary>
 public class AccountService : IAccountService
 {
-    private readonly RegistrationService _registrationService;
-    private readonly AuthenticationService _authenticationService;
-    private readonly ProfileService _profileService;
-    private readonly AdminService _adminService;
+    private readonly IRegistrationService _registrationService;
+    private readonly IAuthenticationService _authenticationService;
+    private readonly IProfileService _profileService;
+    private readonly IAdminService _adminService;
 
     internal AccountService(
-        RegistrationService registrationService,
-        AuthenticationService authenticationService,
-        ProfileService profileService,
-        AdminService adminService)
+        IRegistrationService registrationService,
+        IAuthenticationService authenticationService,
+        IProfileService profileService,
+        IAdminService adminService)
     {
         _registrationService = registrationService ?? throw new ArgumentNullException(nameof(registrationService));
         _authenticationService = authenticationService ?? throw new ArgumentNullException(nameof(authenticationService));


### PR DESCRIPTION
…r the three services

----
## Summary by Gitar

- **Interface Segregation:**
  - Introduced `IAdminService`, `IAuthenticationService`, `IProfileService`, and `IRegistrationService` to decouple core account services.
  - Updated implementation classes to inherit from their respective new interfaces.
- **Dependency Injection:**
  - Refactored `DependencyInjectionExtensions.cs` and `AccountService` to inject interface abstractions rather than concrete service implementations.
- **Testing:**
  - Added comprehensive unit test suites for `AccountService`, `ClassroomService`, and `CourseService`.

<sub>This will update automatically on new commits.</sub>