### PR TITLE
feat: create endpoints and API for instructor page where they can view classes and sections 

### DIFF
--- a/attendance.testproject/Controllers_Testing/InstructorControllerTest.cs
+++ b/attendance.testproject/Controllers_Testing/InstructorControllerTest.cs
@@ -262,4 +262,357 @@ public class InstructorControllerTest
     }
 
     #endregion
+
+    #region GetMySectionsOverview Tests
+
+    [Fact]
+    public async Task GetMySectionsOverview_ReturnsOkResult_WithSectionsOverviewList()
+    {
+        // Arrange
+        var expectedSections = new List<InstructorSectionOverviewDto>
+        {
+            new InstructorSectionOverviewDto
+            {
+                SectionId = 1,
+                SectionUuid = Guid.NewGuid(),
+                SectionName = "BSCS 3A",
+                CourseId = 1,
+                CourseUuid = Guid.NewGuid(),
+                CourseName = "Computer Science",
+                HandledClassCount = 2,
+                UniqueStudentCount = 30
+            },
+            new InstructorSectionOverviewDto
+            {
+                SectionId = 2,
+                SectionUuid = Guid.NewGuid(),
+                SectionName = "BSCS 3B",
+                CourseId = 1,
+                CourseUuid = Guid.NewGuid(),
+                CourseName = "Computer Science",
+                HandledClassCount = 1,
+                UniqueStudentCount = 25
+            }
+        };
+        _mockInstructorService
+            .Setup(s => s.GetInstructorSectionsOverviewAsync(It.IsAny<ClaimsPrincipal>()))
+            .ReturnsAsync(expectedSections);
+
+        // Act
+        var result = await _instructorController.GetMySectionsOverview();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var sections = Assert.IsAssignableFrom<List<InstructorSectionOverviewDto>>(okResult.Value);
+        Assert.Equal(2, sections.Count);
+        _mockInstructorService.Verify(s => s.GetInstructorSectionsOverviewAsync(It.IsAny<ClaimsPrincipal>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetMySectionsOverview_ReturnsOkResult_WithEmptyList_WhenNoSections()
+    {
+        // Arrange
+        var expectedSections = new List<InstructorSectionOverviewDto>();
+        _mockInstructorService
+            .Setup(s => s.GetInstructorSectionsOverviewAsync(It.IsAny<ClaimsPrincipal>()))
+            .ReturnsAsync(expectedSections);
+
+        // Act
+        var result = await _instructorController.GetMySectionsOverview();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var sections = Assert.IsAssignableFrom<List<InstructorSectionOverviewDto>>(okResult.Value);
+        Assert.Empty(sections);
+        _mockInstructorService.Verify(s => s.GetInstructorSectionsOverviewAsync(It.IsAny<ClaimsPrincipal>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetMySectionsOverview_ReturnsNotFound_WhenInstructorNotFound()
+    {
+        // Arrange
+        _mockInstructorService
+            .Setup(s => s.GetInstructorSectionsOverviewAsync(It.IsAny<ClaimsPrincipal>()))
+            .ThrowsAsync(new attendance_monitoring.Exceptions.EntityNotFoundException<string>("Instructor", "UserId: 1"));
+
+        // Act
+        var result = await _instructorController.GetMySectionsOverview();
+
+        // Assert
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
+        Assert.Equal("No instructor record found for the current user", notFoundResult.Value);
+        _mockInstructorService.Verify(s => s.GetInstructorSectionsOverviewAsync(It.IsAny<ClaimsPrincipal>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetMySectionsOverview_ReturnsInternalServerError_WhenServiceExceptionOccurs()
+    {
+        // Arrange
+        _mockInstructorService
+            .Setup(s => s.GetInstructorSectionsOverviewAsync(It.IsAny<ClaimsPrincipal>()))
+            .ThrowsAsync(new attendance_monitoring.Exceptions.EntityServiceException("Instructor", "GetInstructorSectionsOverview", "Service error"));
+
+        // Act
+        var result = await _instructorController.GetMySectionsOverview();
+
+        // Assert
+        var statusCodeResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(500, statusCodeResult.StatusCode);
+        Assert.Equal("An error occurred while retrieving sections overview", statusCodeResult.Value);
+        _mockInstructorService.Verify(s => s.GetInstructorSectionsOverviewAsync(It.IsAny<ClaimsPrincipal>()), Times.Once);
+    }
+
+    #endregion
+
+    #region GetMySectionDetail Tests
+
+    [Fact]
+    public async Task GetMySectionDetail_ReturnsOkResult_WithSectionDetail()
+    {
+        // Arrange
+        var sectionId = 1;
+        var expectedDetail = new InstructorSectionDetailDto
+        {
+            SectionId = sectionId,
+            SectionUuid = Guid.NewGuid(),
+            SectionName = "BSCS 3A",
+            CourseId = 1,
+            CourseUuid = Guid.NewGuid(),
+            CourseName = "Computer Science",
+            HandledClassCount = 2,
+            HomeSectionStudentCount = 30,
+            HandledClasses = new List<InstructorHandledClassDto>
+            {
+                new InstructorHandledClassDto
+                {
+                    SubjectId = 1,
+                    SubjectUuid = Guid.NewGuid(),
+                    SubjectName = "Data Structures",
+                    SubjectCode = "CS301",
+                    ScheduleId = 1,
+                    ScheduleUuid = Guid.NewGuid(),
+                    DayOfWeek = "Monday",
+                    TimeIn = new TimeOnly(8, 0),
+                    TimeOut = new TimeOnly(10, 0),
+                    ClassroomId = 1,
+                    ClassroomUuid = Guid.NewGuid(),
+                    ClassroomName = "Room 101",
+                    StudentCount = 30,
+                    Students = new List<InstructorHandledClassStudentDto>()
+                }
+            },
+            HomeSectionStudents = new List<InstructorHomeSectionStudentDto>()
+        };
+        _mockInstructorService
+            .Setup(s => s.GetInstructorSectionDetailAsync(It.IsAny<ClaimsPrincipal>(), sectionId))
+            .ReturnsAsync(expectedDetail);
+
+        // Act
+        var result = await _instructorController.GetMySectionDetail(sectionId);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var detail = Assert.IsType<InstructorSectionDetailDto>(okResult.Value);
+        Assert.Equal(sectionId, detail.SectionId);
+        Assert.Equal("BSCS 3A", detail.SectionName);
+        _mockInstructorService.Verify(s => s.GetInstructorSectionDetailAsync(It.IsAny<ClaimsPrincipal>(), sectionId), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetMySectionDetail_ReturnsNotFound_WhenInstructorNotFound()
+    {
+        // Arrange
+        var sectionId = 1;
+        _mockInstructorService
+            .Setup(s => s.GetInstructorSectionDetailAsync(It.IsAny<ClaimsPrincipal>(), sectionId))
+            .ThrowsAsync(new attendance_monitoring.Exceptions.EntityNotFoundException<string>("Instructor", "UserId: 1"));
+
+        // Act
+        var result = await _instructorController.GetMySectionDetail(sectionId);
+
+        // Assert
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
+        Assert.Equal("No instructor record found for the current user", notFoundResult.Value);
+    }
+
+    [Fact]
+    public async Task GetMySectionDetail_ReturnsNotFound_WhenSectionNotFound()
+    {
+        // Arrange
+        var sectionId = 999;
+        _mockInstructorService
+            .Setup(s => s.GetInstructorSectionDetailAsync(It.IsAny<ClaimsPrincipal>(), sectionId))
+            .ThrowsAsync(new attendance_monitoring.Exceptions.EntityNotFoundException<int>("Section", sectionId));
+
+        // Act
+        var result = await _instructorController.GetMySectionDetail(sectionId);
+
+        // Assert
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
+        Assert.Equal($"Section with ID {sectionId} not found", notFoundResult.Value);
+    }
+
+    [Fact]
+    public async Task GetMySectionDetail_ReturnsUnauthorized_WhenNotAuthorized()
+    {
+        // Arrange
+        var sectionId = 1;
+        _mockInstructorService
+            .Setup(s => s.GetInstructorSectionDetailAsync(It.IsAny<ClaimsPrincipal>(), sectionId))
+            .ThrowsAsync(new attendance_monitoring.Exceptions.EntityUnauthorizedException("Section", "View section", "1", "You are not authorized to view this section"));
+
+        // Act
+        var result = await _instructorController.GetMySectionDetail(sectionId);
+
+        // Assert
+        var unauthorizedResult = Assert.IsType<UnauthorizedObjectResult>(result.Result);
+        Assert.Equal("You are not authorized to view this section", unauthorizedResult.Value);
+    }
+
+    [Fact]
+    public async Task GetMySectionDetail_ReturnsInternalServerError_WhenServiceExceptionOccurs()
+    {
+        // Arrange
+        var sectionId = 1;
+        _mockInstructorService
+            .Setup(s => s.GetInstructorSectionDetailAsync(It.IsAny<ClaimsPrincipal>(), sectionId))
+            .ThrowsAsync(new attendance_monitoring.Exceptions.EntityServiceException("Instructor", "GetInstructorSectionDetail", "Service error"));
+
+        // Act
+        var result = await _instructorController.GetMySectionDetail(sectionId);
+
+        // Assert
+        var statusCodeResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(500, statusCodeResult.StatusCode);
+        Assert.Equal("An error occurred while retrieving section detail", statusCodeResult.Value);
+    }
+
+    #endregion
+
+    #region GetMyStudentDetail Tests
+
+    [Fact]
+    public async Task GetMyStudentDetail_ReturnsOkResult_WithStudentDetail()
+    {
+        // Arrange
+        var studentId = 1;
+        var expectedDetail = new InstructorStudentDetailDto
+        {
+            StudentId = studentId,
+            StudentUuid = Guid.NewGuid(),
+            Firstname = "Alice",
+            Lastname = "Smith",
+            SectionId = 1,
+            SectionName = "BSCS 3A",
+            CourseId = 1,
+            CourseName = "Computer Science",
+            IsRegular = true,
+            EnrollmentType = "Regular",
+            Enrollments = new List<InstructorStudentEnrollmentDto>
+            {
+                new InstructorStudentEnrollmentDto
+                {
+                    SubjectId = 1,
+                    SubjectName = "Data Structures",
+                    SubjectCode = "CS301",
+                    SectionId = 1,
+                    SectionName = "BSCS 3A",
+                    EnrollmentType = "Regular"
+                }
+            },
+            AttendanceSummary = new InstructorStudentAttendanceSummaryDto
+            {
+                TotalSessions = 10,
+                PresentCount = 8,
+                AbsentCount = 1,
+                LateCount = 1,
+                AttendanceRate = 90.0
+            }
+        };
+        _mockInstructorService
+            .Setup(s => s.GetInstructorStudentDetailAsync(It.IsAny<ClaimsPrincipal>(), studentId))
+            .ReturnsAsync(expectedDetail);
+
+        // Act
+        var result = await _instructorController.GetMyStudentDetail(studentId);
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var detail = Assert.IsType<InstructorStudentDetailDto>(okResult.Value);
+        Assert.Equal(studentId, detail.StudentId);
+        Assert.Equal("Alice", detail.Firstname);
+        Assert.Equal("Smith", detail.Lastname);
+        _mockInstructorService.Verify(s => s.GetInstructorStudentDetailAsync(It.IsAny<ClaimsPrincipal>(), studentId), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetMyStudentDetail_ReturnsNotFound_WhenInstructorNotFound()
+    {
+        // Arrange
+        var studentId = 1;
+        _mockInstructorService
+            .Setup(s => s.GetInstructorStudentDetailAsync(It.IsAny<ClaimsPrincipal>(), studentId))
+            .ThrowsAsync(new attendance_monitoring.Exceptions.EntityNotFoundException<string>("Instructor", "UserId: 1"));
+
+        // Act
+        var result = await _instructorController.GetMyStudentDetail(studentId);
+
+        // Assert
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
+        Assert.Equal("No instructor record found for the current user", notFoundResult.Value);
+    }
+
+    [Fact]
+    public async Task GetMyStudentDetail_ReturnsNotFound_WhenStudentNotFound()
+    {
+        // Arrange
+        var studentId = 999;
+        _mockInstructorService
+            .Setup(s => s.GetInstructorStudentDetailAsync(It.IsAny<ClaimsPrincipal>(), studentId))
+            .ThrowsAsync(new attendance_monitoring.Exceptions.EntityNotFoundException<int>("Student", studentId));
+
+        // Act
+        var result = await _instructorController.GetMyStudentDetail(studentId);
+
+        // Assert
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
+        Assert.Equal($"Student with ID {studentId} not found", notFoundResult.Value);
+    }
+
+    [Fact]
+    public async Task GetMyStudentDetail_ReturnsUnauthorized_WhenNotAuthorized()
+    {
+        // Arrange
+        var studentId = 1;
+        _mockInstructorService
+            .Setup(s => s.GetInstructorStudentDetailAsync(It.IsAny<ClaimsPrincipal>(), studentId))
+            .ThrowsAsync(new attendance_monitoring.Exceptions.EntityUnauthorizedException("Student", "View student", "1", "You are not authorized to view this student"));
+
+        // Act
+        var result = await _instructorController.GetMyStudentDetail(studentId);
+
+        // Assert
+        var unauthorizedResult = Assert.IsType<UnauthorizedObjectResult>(result.Result);
+        Assert.Equal("You are not authorized to view this student", unauthorizedResult.Value);
+    }
+
+    [Fact]
+    public async Task GetMyStudentDetail_ReturnsInternalServerError_WhenServiceExceptionOccurs()
+    {
+        // Arrange
+        var studentId = 1;
+        _mockInstructorService
+            .Setup(s => s.GetInstructorStudentDetailAsync(It.IsAny<ClaimsPrincipal>(), studentId))
+            .ThrowsAsync(new attendance_monitoring.Exceptions.EntityServiceException("Instructor", "GetInstructorStudentDetail", "Service error"));
+
+        // Act
+        var result = await _instructorController.GetMyStudentDetail(studentId);
+
+        // Assert
+        var statusCodeResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(500, statusCodeResult.StatusCode);
+        Assert.Equal("An error occurred while retrieving student detail", statusCodeResult.Value);
+    }
+
+    #endregion
 }

--- a/attendance.testproject/Controllers_Testing/InstructorControllerTest.cs
+++ b/attendance.testproject/Controllers_Testing/InstructorControllerTest.cs
@@ -453,7 +453,7 @@ public class InstructorControllerTest
     }
 
     [Fact]
-    public async Task GetMySectionDetail_ReturnsUnauthorized_WhenNotAuthorized()
+    public async Task GetMySectionDetail_ReturnsForbidden_WhenNotAuthorized()
     {
         // Arrange
         var sectionId = 1;
@@ -465,8 +465,9 @@ public class InstructorControllerTest
         var result = await _instructorController.GetMySectionDetail(sectionId);
 
         // Assert
-        var unauthorizedResult = Assert.IsType<UnauthorizedObjectResult>(result.Result);
-        Assert.Equal("You are not authorized to view this section", unauthorizedResult.Value);
+        var forbiddenResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(403, forbiddenResult.StatusCode);
+        Assert.Equal("You are not authorized to view this section", forbiddenResult.Value);
     }
 
     [Fact]
@@ -580,7 +581,7 @@ public class InstructorControllerTest
     }
 
     [Fact]
-    public async Task GetMyStudentDetail_ReturnsUnauthorized_WhenNotAuthorized()
+    public async Task GetMyStudentDetail_ReturnsForbidden_WhenNotAuthorized()
     {
         // Arrange
         var studentId = 1;
@@ -592,8 +593,9 @@ public class InstructorControllerTest
         var result = await _instructorController.GetMyStudentDetail(studentId);
 
         // Assert
-        var unauthorizedResult = Assert.IsType<UnauthorizedObjectResult>(result.Result);
-        Assert.Equal("You are not authorized to view this student", unauthorizedResult.Value);
+        var forbiddenResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(403, forbiddenResult.StatusCode);
+        Assert.Equal("You are not authorized to view this student", forbiddenResult.Value);
     }
 
     [Fact]

--- a/attendance.testproject/Controllers_Testing/InstructorControllerTest.cs
+++ b/attendance.testproject/Controllers_Testing/InstructorControllerTest.cs
@@ -160,4 +160,106 @@ public class InstructorControllerTest
     }
 
     #endregion
+
+    #region GetMySectionsWithStudents Tests
+
+    [Fact]
+    public async Task GetMySectionsWithStudents_ReturnsOkResult_WithSectionsAndStudents()
+    {
+        // Arrange
+        var expectedResponse = new InstructorSectionsWithStudentsResponseDto
+        {
+            InstructorId = 1,
+            InstructorUuid = Guid.NewGuid(),
+            InstructorFirstname = "John",
+            InstructorLastname = "Doe",
+            Sections = new List<SectionWithStudentsDto>
+            {
+                new SectionWithStudentsDto
+                {
+                    SectionId = 1,
+                    SectionName = "BSCS 3A",
+                    CourseId = 1,
+                    CourseName = "Bachelor of Science in Computer Science",
+                    Subjects = new List<SubjectScheduleDto>
+                    {
+                        new SubjectScheduleDto
+                        {
+                            SubjectId = 1,
+                            SubjectName = "Data Structures",
+                            SubjectCode = "CS301",
+                            ScheduleId = 1,
+                            DayOfWeek = "Monday",
+                            TimeIn = new TimeOnly(8, 0),
+                            TimeOut = new TimeOnly(10, 0),
+                            ClassroomName = "Room 101",
+                            Students = new List<StudentDto>
+                            {
+                                new StudentDto
+                                {
+                                    StudentId = 1,
+                                    Firstname = "Alice",
+                                    Lastname = "Smith",
+                                    IsRegular = true,
+                                    EnrollmentType = "Regular"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        _mockInstructorService
+            .Setup(s => s.GetSectionsWithStudentsByInstructorAsync(It.IsAny<ClaimsPrincipal>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _instructorController.GetMySectionsWithStudents();
+
+        // Assert
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var response = Assert.IsType<InstructorSectionsWithStudentsResponseDto>(okResult.Value);
+        Assert.Equal(1, response.InstructorId);
+        Assert.Equal("John", response.InstructorFirstname);
+        Assert.Equal("Doe", response.InstructorLastname);
+        Assert.Single(response.Sections);
+        _mockInstructorService.Verify(s => s.GetSectionsWithStudentsByInstructorAsync(It.IsAny<ClaimsPrincipal>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetMySectionsWithStudents_ReturnsNotFound_WhenInstructorNotFound()
+    {
+        // Arrange
+        _mockInstructorService
+            .Setup(s => s.GetSectionsWithStudentsByInstructorAsync(It.IsAny<ClaimsPrincipal>()))
+            .ThrowsAsync(new attendance_monitoring.Exceptions.EntityNotFoundException<string>("Instructor", "UserId: 1"));
+
+        // Act
+        var result = await _instructorController.GetMySectionsWithStudents();
+
+        // Assert
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
+        Assert.Equal("No instructor record found for the current user", notFoundResult.Value);
+        _mockInstructorService.Verify(s => s.GetSectionsWithStudentsByInstructorAsync(It.IsAny<ClaimsPrincipal>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetMySectionsWithStudents_ReturnsInternalServerError_WhenServiceExceptionOccurs()
+    {
+        // Arrange
+        _mockInstructorService
+            .Setup(s => s.GetSectionsWithStudentsByInstructorAsync(It.IsAny<ClaimsPrincipal>()))
+            .ThrowsAsync(new attendance_monitoring.Exceptions.EntityServiceException("Instructor", "GetSectionsWithStudentsByInstructor", "Service error"));
+
+        // Act
+        var result = await _instructorController.GetMySectionsWithStudents();
+
+        // Assert
+        var statusCodeResult = Assert.IsType<ObjectResult>(result.Result);
+        Assert.Equal(500, statusCodeResult.StatusCode);
+        Assert.Equal("An error occurred while retrieving sections", statusCodeResult.Value);
+        _mockInstructorService.Verify(s => s.GetSectionsWithStudentsByInstructorAsync(It.IsAny<ClaimsPrincipal>()), Times.Once);
+    }
+
+    #endregion
 }

--- a/attendance.testproject/Controllers_Testing/StudentEnrollmentControllerTest.cs
+++ b/attendance.testproject/Controllers_Testing/StudentEnrollmentControllerTest.cs
@@ -1,11 +1,13 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using System.ComponentModel.DataAnnotations;
 using attendance_monitoring.Controllers;
 using attendance_monitoring.IServices;
 using attendance_monitoring.Classes;
 using attendance_monitoring.Models.DTO.Request;
 using attendance_monitoring.Models.DTO.Response;
 using attendance_monitoring.Exceptions;
+using AppValidationException = attendance_monitoring.Exceptions.ValidationException;
 
 namespace attendance.testproject.Controllers_Testing;
 
@@ -219,6 +221,56 @@ public class StudentEnrollmentControllerTest
         // Assert
         var conflictResult = Assert.IsType<ConflictObjectResult>(result.Result);
         Assert.NotNull(conflictResult.Value);
+    }
+
+    [Fact]
+    public async Task EnrollStudent_InvalidEnrollmentTypeFromService_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new CreateStudentEnrollment
+        {
+            StudentId = 1,
+            SectionId = 2,
+            SubjectId = 3,
+            EnrollmentType = "Elective"
+        };
+
+        _mockService.Setup(s => s.EnrollStudentAsync(
+            request.StudentId,
+            request.SectionId,
+            request.SubjectId,
+            request.EnrollmentType,
+            request.AcademicYear,
+            request.Semester))
+            .ThrowsAsync(new AppValidationException("Enrollment type must be one of: Regular, Irregular, Retake"));
+
+        // Act
+        var result = await _controller.EnrollStudent(request);
+
+        // Assert
+        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.NotNull(badRequestResult.Value);
+    }
+
+    [Fact]
+    public void CreateStudentEnrollment_InvalidEnrollmentType_FailsValidation()
+    {
+        // Arrange
+        var request = new CreateStudentEnrollment
+        {
+            StudentId = 1,
+            SectionId = 2,
+            SubjectId = 3,
+            EnrollmentType = "Elective"
+        };
+        var validationResults = new List<ValidationResult>();
+
+        // Act
+        var isValid = Validator.TryValidateObject(request, new ValidationContext(request), validationResults, true);
+
+        // Assert
+        Assert.False(isValid);
+        Assert.Contains(validationResults, result => result.ErrorMessage == "Enrollment type must be one of: Regular, Irregular, Retake");
     }
 
     #endregion

--- a/attendance.testproject/Integration_Testing/InstructorSectionsIntegrationTests.cs
+++ b/attendance.testproject/Integration_Testing/InstructorSectionsIntegrationTests.cs
@@ -1,0 +1,125 @@
+using System.Net;
+using System.Net.Http.Json;
+using attendance_monitoring.Classes;
+using attendance_monitoring.Data;
+using attendance_monitoring.Models.DTO.Response;
+using attendance.testproject.Integration_Testing.Support;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace attendance.testproject.Integration_Testing;
+
+/// <summary>
+/// Integration tests for the instructor sections with students endpoint.
+/// Tests the full stack with real database and authentication.
+/// </summary>
+public sealed class InstructorSectionsIntegrationTests
+{
+    [RequiresEnvironmentVariableFact("RUN_INTEGRATION_TESTS")]
+    public async Task GetMySectionsWithStudents_AuthenticatedInstructor_Returns200WithCorrectDataStructure()
+    {
+        // Arrange
+        await using var host = await CreateHostWithInstructorScenarioAsync();
+        var scenario = host.InstructorScenario!;
+        
+        host.AuthenticateAs(
+            userId: scenario.InstructorUserId,
+            username: scenario.InstructorUsername,
+            role: "Instructor");
+
+        // Act
+        var response = await host.Client.GetAsync("/api/instructors/me/sections-with-students");
+        var payload = await response.Content.ReadFromJsonAsync<InstructorSectionsWithStudentsResponseDto>();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(payload);
+        Assert.Equal(scenario.InstructorId, payload.InstructorId);
+        Assert.Equal(scenario.InstructorFirstname, payload.InstructorFirstname);
+        Assert.Equal(scenario.InstructorLastname, payload.InstructorLastname);
+        Assert.NotNull(payload.Sections);
+        Assert.NotEmpty(payload.Sections);
+        
+        // Verify data structure
+        var firstSection = payload.Sections[0];
+        Assert.True(firstSection.SectionId > 0);
+        Assert.False(string.IsNullOrEmpty(firstSection.SectionName));
+        Assert.False(string.IsNullOrEmpty(firstSection.CourseName));
+        Assert.NotNull(firstSection.Subjects);
+        Assert.NotEmpty(firstSection.Subjects);
+        
+        var firstSubject = firstSection.Subjects[0];
+        Assert.True(firstSubject.SubjectId > 0);
+        Assert.False(string.IsNullOrEmpty(firstSubject.SubjectName));
+        Assert.False(string.IsNullOrEmpty(firstSubject.SubjectCode));
+        Assert.True(firstSubject.ScheduleId > 0);
+        Assert.NotNull(firstSubject.Students);
+    }
+
+    [RequiresEnvironmentVariableFact("RUN_INTEGRATION_TESTS")]
+    public async Task GetMySectionsWithStudents_UnauthenticatedRequest_Returns401Unauthorized()
+    {
+        // Arrange
+        await using var host = await CreateHostWithInstructorScenarioAsync();
+        
+        // Do not authenticate - no Authorization header
+
+        // Act
+        var response = await host.Client.GetAsync("/api/instructors/me/sections-with-students");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [RequiresEnvironmentVariableFact("RUN_INTEGRATION_TESTS")]
+    public async Task GetMySectionsWithStudents_NonInstructorUser_Returns404NotFound()
+    {
+        // Arrange
+        await using var host = await CreateHostWithInstructorScenarioAsync();
+        
+        // Authenticate as a user who is not an instructor (no instructor record)
+        host.AuthenticateAs(
+            userId: "non-instructor-user-id",
+            username: "student-user",
+            role: "Student");
+
+        // Act
+        var response = await host.Client.GetAsync("/api/instructors/me/sections-with-students");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var content = await response.Content.ReadAsStringAsync();
+        Assert.Contains("No instructor record found", content);
+    }
+
+    [RequiresEnvironmentVariableFact("RUN_INTEGRATION_TESTS")]
+    public async Task GetMySectionsWithStudents_InstructorWithNoSchedules_Returns200WithEmptySections()
+    {
+        // Arrange
+        await using var host = await CreateHostWithInstructorScenarioAsync();
+        var scenario = host.InstructorScenario!;
+        
+        host.AuthenticateAs(
+            userId: scenario.InstructorWithNoSchedulesUserId,
+            username: scenario.InstructorWithNoSchedulesUsername,
+            role: "Instructor");
+
+        // Act
+        var response = await host.Client.GetAsync("/api/instructors/me/sections-with-students");
+        var payload = await response.Content.ReadFromJsonAsync<InstructorSectionsWithStudentsResponseDto>();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.NotNull(payload);
+        Assert.Equal(scenario.InstructorWithNoSchedulesId, payload.InstructorId);
+        Assert.NotNull(payload.Sections);
+        Assert.Empty(payload.Sections);
+    }
+
+    private static async Task<ApiIntegrationHost> CreateHostWithInstructorScenarioAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var host = await ApiIntegrationHost.CreateInstructorSectionsAsync(cancellationToken);
+        return host;
+    }
+}

--- a/attendance.testproject/Integration_Testing/InstructorSectionsIntegrationTests.cs
+++ b/attendance.testproject/Integration_Testing/InstructorSectionsIntegrationTests.cs
@@ -54,6 +54,8 @@ public sealed class InstructorSectionsIntegrationTests
         Assert.False(string.IsNullOrEmpty(firstSubject.SubjectCode));
         Assert.True(firstSubject.ScheduleId > 0);
         Assert.NotNull(firstSubject.Students);
+        Assert.NotEmpty(firstSubject.Students);
+        Assert.Contains(firstSubject.Students, student => student.IsRegular);
     }
 
     [RequiresEnvironmentVariableFact("RUN_INTEGRATION_TESTS")]

--- a/attendance.testproject/Integration_Testing/Support/ApiIntegrationHost.cs
+++ b/attendance.testproject/Integration_Testing/Support/ApiIntegrationHost.cs
@@ -71,6 +71,8 @@ internal sealed class ApiIntegrationHost : IAsyncDisposable
 
     public AdminUserManagementScenarioContext? AdminUserManagementScenario { get; private set; }
 
+    public InstructorScenarioContext? InstructorScenario { get; private set; }
+
     public IServiceProvider Services => _app.Services;
 
     public ReliabilityTelemetryCollector Telemetry => _telemetryCollector
@@ -448,6 +450,86 @@ internal sealed class ApiIntegrationHost : IAsyncDisposable
         return host;
     }
 
+    public static async Task<ApiIntegrationHost> CreateInstructorSectionsAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var connectionString = $"Data Source=file:instructor-sections-{Guid.NewGuid():N}?mode=memory&cache=shared";
+        var connection = new SqliteConnection(connectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Production
+        });
+
+        builder.WebHost.UseTestServer();
+        builder.Services.AddLogging();
+        builder.Services.AddRouting();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["CookieSettings:AccessTokenExpirationMinutes"] = "15",
+            ["CookieSettings:RefreshTokenExpirationDays"] = "7",
+            ["CorsSettings:AllowedOrigins"] = "https://localhost",
+            ["Jwt:Token"] = "test-secret-key-for-integration-testing-minimum-32-characters",
+            ["Jwt:Issuer"] = "test-issuer",
+            ["Jwt:Audience"] = "test-audience",
+            ["TimeZoneSettings:TimeZoneId"] = TimeZoneInfo.Local.Id
+        });
+
+        builder.Services.AddDbContext<ApplicationDbContext>(options => options.UseSqlite(connectionString));
+        builder.Services.AddIdentity<IdentityUser, IdentityRole>(options =>
+        {
+            options.Password.RequireDigit = true;
+            options.Password.RequiredLength = 8;
+            options.Password.RequireNonAlphanumeric = true;
+            options.Password.RequireUppercase = true;
+            options.Password.RequireLowercase = true;
+        })
+            .AddEntityFrameworkStores<ApplicationDbContext>()
+            .AddDefaultTokenProviders();
+        builder.Services
+            .AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = AuthenticationScheme;
+                options.DefaultChallengeScheme = AuthenticationScheme;
+                options.DefaultScheme = AuthenticationScheme;
+            })
+            .AddScheme<AuthenticationSchemeOptions, TestAuthenticationHandler>(AuthenticationScheme, _ => { });
+        builder.Services.ConfigureApplicationCookie(options =>
+        {
+            options.LoginPath = PathString.Empty;
+            options.AccessDeniedPath = PathString.Empty;
+        });
+        builder.Services.AddAuthorizationPolicies();
+        builder.Services.AddResponseHandling();
+        builder.Services.AddCorsPolicy(builder.Configuration);
+        builder.Services.AddSignalRServices();
+        builder.Services.AddRepositories();
+        builder.Services.AddApplicationServices();
+        builder.Services.AddControllers()
+            .ConfigureApplicationPartManager(manager =>
+            {
+                manager.ApplicationParts.Clear();
+                manager.ApplicationParts.Add(new AssemblyPart(typeof(InstructorController).Assembly));
+            });
+
+        var app = builder.Build();
+        app.UseRouting();
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.UseGlobalExceptionHandler();
+        app.MapControllers();
+
+        await app.StartAsync(cancellationToken);
+
+        var client = app.GetTestClient();
+        client.BaseAddress = new Uri("https://localhost");
+
+        var host = new ApiIntegrationHost(app, client, sqliteConnection: connection);
+        await host.LoadInstructorScenarioAsync(cancellationToken);
+        return host;
+    }
+
     public void AuthenticateAs(
         string userId = "integration-user",
         string username = "integration-admin",
@@ -555,6 +637,15 @@ internal sealed class ApiIntegrationHost : IAsyncDisposable
             roleManager,
             cancellationToken);
         return AdminUserManagementScenario;
+    }
+
+    public async Task<InstructorScenarioContext> LoadInstructorScenarioAsync(
+        CancellationToken cancellationToken = default)
+    {
+        await using var scope = _app.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        InstructorScenario = await InstructorSeedData.SeedScenarioAsync(dbContext, cancellationToken);
+        return InstructorScenario;
     }
 
     public async Task<TResult> ExecuteDbContextAsync<TResult>(

--- a/attendance.testproject/Integration_Testing/Support/InstructorScenarioContext.cs
+++ b/attendance.testproject/Integration_Testing/Support/InstructorScenarioContext.cs
@@ -1,0 +1,16 @@
+namespace attendance.testproject.Integration_Testing.Support;
+
+/// <summary>
+/// Context for instructor sections integration test scenario.
+/// </summary>
+internal sealed class InstructorScenarioContext
+{
+    public required int InstructorId { get; init; }
+    public required string InstructorUserId { get; init; }
+    public required string InstructorUsername { get; init; }
+    public required string InstructorFirstname { get; init; }
+    public required string InstructorLastname { get; init; }
+    public required int InstructorWithNoSchedulesId { get; init; }
+    public required string InstructorWithNoSchedulesUserId { get; init; }
+    public required string InstructorWithNoSchedulesUsername { get; init; }
+}

--- a/attendance.testproject/Integration_Testing/Support/InstructorSeedData.cs
+++ b/attendance.testproject/Integration_Testing/Support/InstructorSeedData.cs
@@ -1,0 +1,227 @@
+using attendance_monitoring.Classes;
+using attendance_monitoring.Data;
+using Microsoft.AspNetCore.Identity;
+
+namespace attendance.testproject.Integration_Testing.Support;
+
+/// <summary>
+/// Seed data for instructor sections integration tests.
+/// </summary>
+internal static class InstructorSeedData
+{
+    public static async Task<InstructorScenarioContext> SeedScenarioAsync(
+        ApplicationDbContext dbContext,
+        CancellationToken cancellationToken = default)
+    {
+        await dbContext.Database.EnsureDeletedAsync(cancellationToken);
+        await dbContext.Database.EnsureCreatedAsync(cancellationToken);
+
+        var now = DateTime.UtcNow;
+
+        // Create Identity users
+        var instructorUser = CreateIdentityUser("instructor-user-1", "instructor1@example.test");
+        var instructorWithNoSchedulesUser = CreateIdentityUser("instructor-user-2", "instructor2@example.test");
+
+        dbContext.Users.AddRange(instructorUser, instructorWithNoSchedulesUser);
+
+        // Create course
+        var course = new Course
+        {
+            Name = "Bachelor of Science in Computer Science",
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        // Create sections
+        var section1 = new Section
+        {
+            Name = "BSCS 3A",
+            Course = course,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        var section2 = new Section
+        {
+            Name = "BSCS 3B",
+            Course = course,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        // Create subjects
+        var subject1 = new Subject
+        {
+            Name = "Data Structures",
+            Code = "CS301",
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        var subject2 = new Subject
+        {
+            Name = "Algorithms",
+            Code = "CS302",
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        // Create classrooms
+        var classroom1 = new Classroom
+        {
+            Name = "Room 101",
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        var classroom2 = new Classroom
+        {
+            Name = "Room 102",
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        // Create instructors
+        var instructor = new Instructor
+        {
+            UserId = instructorUser.Id,
+            Firstname = "John",
+            Lastname = "Doe",
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        var instructorWithNoSchedules = new Instructor
+        {
+            UserId = instructorWithNoSchedulesUser.Id,
+            Firstname = "Jane",
+            Lastname = "Smith",
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        // Create students
+        var regularStudent1 = new Student
+        {
+            UserId = "student-user-1",
+            Firstname = "Alice",
+            Lastname = "Johnson",
+            Section = section1,
+            IsRegular = true,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        var regularStudent2 = new Student
+        {
+            UserId = "student-user-2",
+            Firstname = "Bob",
+            Lastname = "Williams",
+            Section = section1,
+            IsRegular = true,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        var irregularStudent = new Student
+        {
+            UserId = "student-user-3",
+            Firstname = "Charlie",
+            Lastname = "Brown",
+            Section = section2,
+            IsRegular = false,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        // Create schedules for instructor with sections
+        var schedule1 = new Schedules
+        {
+            Subject = subject1,
+            Section = section1,
+            Classroom = classroom1,
+            Instructor = instructor,
+            DayOfWeek = "Monday",
+            TimeIn = new TimeOnly(8, 0),
+            TimeOut = new TimeOnly(10, 0),
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        var schedule2 = new Schedules
+        {
+            Subject = subject2,
+            Section = section1,
+            Classroom = classroom2,
+            Instructor = instructor,
+            DayOfWeek = "Wednesday",
+            TimeIn = new TimeOnly(10, 0),
+            TimeOut = new TimeOnly(12, 0),
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        dbContext.AddRange(
+            course,
+            section1,
+            section2,
+            subject1,
+            subject2,
+            classroom1,
+            classroom2,
+            instructor,
+            instructorWithNoSchedules,
+            regularStudent1,
+            regularStudent2,
+            irregularStudent,
+            schedule1,
+            schedule2);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        // Create student enrollment for irregular student
+        var irregularEnrollment = new StudentEnrollment
+        {
+            StudentId = irregularStudent.Id,
+            SectionId = section1.Id,
+            SubjectId = subject1.Id,
+            EnrollmentType = "Irregular",
+            IsActive = true,
+            AcademicYear = "2026",
+            Semester = "2nd",
+            EnrolledAt = now,
+            CreatedAt = now,
+            UpdatedAt = now
+        };
+
+        dbContext.StudentEnrollments.Add(irregularEnrollment);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return new InstructorScenarioContext
+        {
+            InstructorId = instructor.Id,
+            InstructorUserId = instructorUser.Id,
+            InstructorUsername = instructorUser.UserName!,
+            InstructorFirstname = instructor.Firstname,
+            InstructorLastname = instructor.Lastname,
+            InstructorWithNoSchedulesId = instructorWithNoSchedules.Id,
+            InstructorWithNoSchedulesUserId = instructorWithNoSchedulesUser.Id,
+            InstructorWithNoSchedulesUsername = instructorWithNoSchedulesUser.UserName!
+        };
+    }
+
+    private static IdentityUser CreateIdentityUser(string id, string email)
+    {
+        return new IdentityUser
+        {
+            Id = id,
+            UserName = email,
+            NormalizedUserName = email.ToUpperInvariant(),
+            Email = email,
+            NormalizedEmail = email.ToUpperInvariant(),
+            SecurityStamp = Guid.NewGuid().ToString("N"),
+            ConcurrencyStamp = Guid.NewGuid().ToString("N"),
+            EmailConfirmed = true
+        };
+    }
+}

--- a/attendance.testproject/Repositories_Testing/InstructorRepositoryTest.cs
+++ b/attendance.testproject/Repositories_Testing/InstructorRepositoryTest.cs
@@ -1,0 +1,602 @@
+using attendance_monitoring.Classes;
+using attendance_monitoring.Data;
+using attendance_monitoring.Repositories;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace attendance.testproject.Repositories_Testing;
+
+/// <summary>
+/// Unit tests for InstructorRepository
+/// Tests GetSchedulesWithRelatedDataByInstructorIdAsync method
+/// </summary>
+public class InstructorRepositoryTest : IDisposable
+{
+    private readonly ApplicationDbContext _context;
+    private readonly InstructorRepository _repository;
+
+    public InstructorRepositoryTest()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        _repository = new InstructorRepository(_context);
+    }
+
+    [Fact]
+    public async Task GetSchedulesWithRelatedDataByInstructorIdAsync_ReturnsSchedulesWithRelatedEntities_WhenInstructorHasSchedules()
+    {
+        // Arrange
+        var instructorId = 1;
+        await SeedTestDataAsync(instructorId);
+
+        // Act
+        var result = await _repository.GetSchedulesWithRelatedDataByInstructorIdAsync(instructorId);
+
+        // Assert
+        var schedules = result.ToList();
+        Assert.NotEmpty(schedules);
+        Assert.Equal(2, schedules.Count);
+
+        // Verify first schedule has all related entities loaded
+        var firstSchedule = schedules[0];
+        Assert.NotNull(firstSchedule.Section);
+        Assert.NotNull(firstSchedule.Section.Course);
+        Assert.NotNull(firstSchedule.Subject);
+        Assert.NotNull(firstSchedule.Classroom);
+        Assert.NotNull(firstSchedule.Section.StudentEnrollments);
+
+        // Verify second schedule has all related entities loaded
+        var secondSchedule = schedules[1];
+        Assert.NotNull(secondSchedule.Section);
+        Assert.NotNull(secondSchedule.Section.Course);
+        Assert.NotNull(secondSchedule.Subject);
+        Assert.NotNull(secondSchedule.Classroom);
+        Assert.NotNull(secondSchedule.Section.StudentEnrollments);
+
+        // Verify data integrity
+        Assert.Equal("Math", firstSchedule.Subject.Name);
+        Assert.Equal("BSCS 3A", firstSchedule.Section.Name);
+        Assert.Equal("Room 101", firstSchedule.Classroom.Name);
+        Assert.Equal("Bachelor of Science in Computer Science", firstSchedule.Section.Course.Name);
+    }
+
+    [Fact]
+    public async Task GetSchedulesWithRelatedDataByInstructorIdAsync_ExcludesDeletedStudents_WhenStudentEnrollmentsExist()
+    {
+        // Arrange
+        var instructorId = 2;
+        await SeedTestDataWithDeletedStudentsAsync(instructorId);
+
+        // Act
+        var result = await _repository.GetSchedulesWithRelatedDataByInstructorIdAsync(instructorId);
+
+        // Assert
+        var schedules = result.ToList();
+        var schedule = Assert.Single(schedules);
+        
+        // Verify only active student enrollments are included
+        var activeEnrollments = schedule.Section.StudentEnrollments.ToList();
+        Assert.Equal(2, activeEnrollments.Count);
+        
+        // Verify all returned enrollments are active
+        Assert.All(activeEnrollments, enrollment => Assert.True(enrollment.IsActive));
+        
+        // Verify students in enrollments are not deleted
+        Assert.All(activeEnrollments, enrollment => 
+        {
+            Assert.NotNull(enrollment.Student);
+            Assert.False(enrollment.Student.IsDeleted);
+        });
+    }
+
+    [Fact]
+    public async Task GetSchedulesWithRelatedDataByInstructorIdAsync_ReturnsEmptyList_WhenInstructorHasNoSchedules()
+    {
+        // Arrange
+        var instructorId = 999; // Non-existent instructor
+        await SeedTestDataAsync(1); // Seed data for different instructor
+
+        // Act
+        var result = await _repository.GetSchedulesWithRelatedDataByInstructorIdAsync(instructorId);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetSchedulesWithRelatedDataByInstructorIdAsync_LoadsStudentEnrollmentsWithStudents_WhenEnrollmentsExist()
+    {
+        // Arrange
+        var instructorId = 3;
+        await SeedTestDataWithIrregularStudentsAsync(instructorId);
+
+        // Act
+        var result = await _repository.GetSchedulesWithRelatedDataByInstructorIdAsync(instructorId);
+
+        // Assert
+        var schedules = result.ToList();
+        var schedule = Assert.Single(schedules);
+        
+        var enrollments = schedule.Section.StudentEnrollments.ToList();
+        Assert.Equal(3, enrollments.Count);
+        
+        // Verify each enrollment has student loaded
+        Assert.All(enrollments, enrollment =>
+        {
+            Assert.NotNull(enrollment.Student);
+            Assert.NotEmpty(enrollment.Student.Firstname);
+            Assert.NotEmpty(enrollment.Student.Lastname);
+        });
+    }
+
+    private async Task SeedTestDataAsync(int instructorId)
+    {
+        var user = new IdentityUser
+        {
+            Id = $"user-{instructorId}",
+            UserName = $"instructor{instructorId}@example.com",
+            NormalizedUserName = $"INSTRUCTOR{instructorId}@EXAMPLE.COM",
+            Email = $"instructor{instructorId}@example.com",
+            NormalizedEmail = $"INSTRUCTOR{instructorId}@EXAMPLE.COM",
+        };
+
+        var course = new Course 
+        { 
+            Id = instructorId, 
+            Name = "Bachelor of Science in Computer Science" 
+        };
+
+        var section = new Section 
+        { 
+            Id = instructorId, 
+            Name = "BSCS 3A", 
+            CourseId = course.Id, 
+            Course = course 
+        };
+
+        var subject1 = new Subject 
+        { 
+            Id = instructorId * 10, 
+            Name = "Math", 
+            Code = "MATH101" 
+        };
+
+        var subject2 = new Subject 
+        { 
+            Id = instructorId * 10 + 1, 
+            Name = "Physics", 
+            Code = "PHYS101" 
+        };
+
+        var classroom = new Classroom 
+        { 
+            Id = instructorId, 
+            Name = "Room 101" 
+        };
+
+        var instructor = new Instructor
+        {
+            Id = instructorId,
+            Firstname = "John",
+            Lastname = "Doe",
+            UserId = user.Id,
+            User = user,
+        };
+
+        var schedule1 = new Schedules
+        {
+            Id = instructorId * 100,
+            TimeIn = new TimeOnly(8, 0),
+            TimeOut = new TimeOnly(10, 0),
+            DayOfWeek = "Monday",
+            SubjectId = subject1.Id,
+            Subject = subject1,
+            ClassroomId = classroom.Id,
+            Classroom = classroom,
+            SectionId = section.Id,
+            Section = section,
+            InstructorId = instructor.Id,
+            Instructor = instructor,
+        };
+
+        var schedule2 = new Schedules
+        {
+            Id = instructorId * 100 + 1,
+            TimeIn = new TimeOnly(10, 0),
+            TimeOut = new TimeOnly(12, 0),
+            DayOfWeek = "Tuesday",
+            SubjectId = subject2.Id,
+            Subject = subject2,
+            ClassroomId = classroom.Id,
+            Classroom = classroom,
+            SectionId = section.Id,
+            Section = section,
+            InstructorId = instructor.Id,
+            Instructor = instructor,
+        };
+
+        _context.Users.Add(user);
+        _context.Courses.Add(course);
+        _context.Sections.Add(section);
+        _context.Subjects.AddRange(subject1, subject2);
+        _context.Classrooms.Add(classroom);
+        _context.Instructors.Add(instructor);
+        _context.Schedules.AddRange(schedule1, schedule2);
+
+        await _context.SaveChangesAsync();
+    }
+
+    private async Task SeedTestDataWithDeletedStudentsAsync(int instructorId)
+    {
+        var user = new IdentityUser
+        {
+            Id = $"user-{instructorId}",
+            UserName = $"instructor{instructorId}@example.com",
+            NormalizedUserName = $"INSTRUCTOR{instructorId}@EXAMPLE.COM",
+            Email = $"instructor{instructorId}@example.com",
+            NormalizedEmail = $"INSTRUCTOR{instructorId}@EXAMPLE.COM",
+        };
+
+        var course = new Course 
+        { 
+            Id = instructorId, 
+            Name = "Bachelor of Science in Information Technology" 
+        };
+
+        var section = new Section 
+        { 
+            Id = instructorId, 
+            Name = "BSIT 2A", 
+            CourseId = course.Id, 
+            Course = course 
+        };
+
+        var subject = new Subject 
+        { 
+            Id = instructorId * 10, 
+            Name = "Database Systems", 
+            Code = "DB101" 
+        };
+
+        var classroom = new Classroom 
+        { 
+            Id = instructorId, 
+            Name = "Room 202" 
+        };
+
+        var instructor = new Instructor
+        {
+            Id = instructorId,
+            Firstname = "Jane",
+            Lastname = "Smith",
+            UserId = user.Id,
+            User = user,
+        };
+
+        var schedule = new Schedules
+        {
+            Id = instructorId * 100,
+            TimeIn = new TimeOnly(13, 0),
+            TimeOut = new TimeOnly(15, 0),
+            DayOfWeek = "Wednesday",
+            SubjectId = subject.Id,
+            Subject = subject,
+            ClassroomId = classroom.Id,
+            Classroom = classroom,
+            SectionId = section.Id,
+            Section = section,
+            InstructorId = instructor.Id,
+            Instructor = instructor,
+        };
+
+        // Create students - some deleted, some active
+        var studentUser1 = new IdentityUser
+        {
+            Id = $"student-{instructorId}-1",
+            UserName = $"student{instructorId}1@example.com",
+            NormalizedUserName = $"STUDENT{instructorId}1@EXAMPLE.COM",
+            Email = $"student{instructorId}1@example.com",
+            NormalizedEmail = $"STUDENT{instructorId}1@EXAMPLE.COM",
+        };
+
+        var studentUser2 = new IdentityUser
+        {
+            Id = $"student-{instructorId}-2",
+            UserName = $"student{instructorId}2@example.com",
+            NormalizedUserName = $"STUDENT{instructorId}2@EXAMPLE.COM",
+            Email = $"student{instructorId}2@example.com",
+            NormalizedEmail = $"STUDENT{instructorId}2@EXAMPLE.COM",
+        };
+
+        var studentUser3 = new IdentityUser
+        {
+            Id = $"student-{instructorId}-3",
+            UserName = $"student{instructorId}3@example.com",
+            NormalizedUserName = $"STUDENT{instructorId}3@EXAMPLE.COM",
+            Email = $"student{instructorId}3@example.com",
+            NormalizedEmail = $"STUDENT{instructorId}3@EXAMPLE.COM",
+        };
+
+        var activeStudent1 = new Student
+        {
+            Id = instructorId * 1000 + 1,
+            Firstname = "Alice",
+            Lastname = "Johnson",
+            UserId = studentUser1.Id,
+            User = studentUser1,
+            SectionId = section.Id,
+            Section = section,
+            IsRegular = true,
+            IsDeleted = false,
+        };
+
+        var activeStudent2 = new Student
+        {
+            Id = instructorId * 1000 + 2,
+            Firstname = "Bob",
+            Lastname = "Williams",
+            UserId = studentUser2.Id,
+            User = studentUser2,
+            SectionId = section.Id,
+            Section = section,
+            IsRegular = false,
+            IsDeleted = false,
+        };
+
+        var deletedStudent = new Student
+        {
+            Id = instructorId * 1000 + 3,
+            Firstname = "Charlie",
+            Lastname = "Brown",
+            UserId = studentUser3.Id,
+            User = studentUser3,
+            SectionId = section.Id,
+            Section = section,
+            IsRegular = true,
+            IsDeleted = true,
+            DeletedAt = DateTime.UtcNow.AddDays(-1),
+        };
+
+        // Create enrollments - active and inactive
+        var activeEnrollment1 = new StudentEnrollment
+        {
+            Id = instructorId * 10000 + 1,
+            StudentId = activeStudent1.Id,
+            Student = activeStudent1,
+            SectionId = section.Id,
+            Section = section,
+            SubjectId = subject.Id,
+            Subject = subject,
+            IsActive = true,
+            EnrollmentType = "Regular",
+        };
+
+        var activeEnrollment2 = new StudentEnrollment
+        {
+            Id = instructorId * 10000 + 2,
+            StudentId = activeStudent2.Id,
+            Student = activeStudent2,
+            SectionId = section.Id,
+            Section = section,
+            SubjectId = subject.Id,
+            Subject = subject,
+            IsActive = true,
+            EnrollmentType = "Irregular",
+        };
+
+        var inactiveEnrollment = new StudentEnrollment
+        {
+            Id = instructorId * 10000 + 3,
+            StudentId = deletedStudent.Id,
+            Student = deletedStudent,
+            SectionId = section.Id,
+            Section = section,
+            SubjectId = subject.Id,
+            Subject = subject,
+            IsActive = false,
+            EnrollmentType = "Regular",
+        };
+
+        _context.Users.AddRange(user, studentUser1, studentUser2, studentUser3);
+        _context.Courses.Add(course);
+        _context.Sections.Add(section);
+        _context.Subjects.Add(subject);
+        _context.Classrooms.Add(classroom);
+        _context.Instructors.Add(instructor);
+        _context.Schedules.Add(schedule);
+        _context.Students.AddRange(activeStudent1, activeStudent2, deletedStudent);
+        _context.StudentEnrollments.AddRange(activeEnrollment1, activeEnrollment2, inactiveEnrollment);
+
+        await _context.SaveChangesAsync();
+    }
+
+    private async Task SeedTestDataWithIrregularStudentsAsync(int instructorId)
+    {
+        var user = new IdentityUser
+        {
+            Id = $"user-{instructorId}",
+            UserName = $"instructor{instructorId}@example.com",
+            NormalizedUserName = $"INSTRUCTOR{instructorId}@EXAMPLE.COM",
+            Email = $"instructor{instructorId}@example.com",
+            NormalizedEmail = $"INSTRUCTOR{instructorId}@EXAMPLE.COM",
+        };
+
+        var course = new Course 
+        { 
+            Id = instructorId, 
+            Name = "Bachelor of Science in Engineering" 
+        };
+
+        var section = new Section 
+        { 
+            Id = instructorId, 
+            Name = "BSE 1A", 
+            CourseId = course.Id, 
+            Course = course 
+        };
+
+        var subject = new Subject 
+        { 
+            Id = instructorId * 10, 
+            Name = "Calculus", 
+            Code = "CALC101" 
+        };
+
+        var classroom = new Classroom 
+        { 
+            Id = instructorId, 
+            Name = "Room 303" 
+        };
+
+        var instructor = new Instructor
+        {
+            Id = instructorId,
+            Firstname = "Robert",
+            Lastname = "Davis",
+            UserId = user.Id,
+            User = user,
+        };
+
+        var schedule = new Schedules
+        {
+            Id = instructorId * 100,
+            TimeIn = new TimeOnly(14, 0),
+            TimeOut = new TimeOnly(16, 0),
+            DayOfWeek = "Thursday",
+            SubjectId = subject.Id,
+            Subject = subject,
+            ClassroomId = classroom.Id,
+            Classroom = classroom,
+            SectionId = section.Id,
+            Section = section,
+            InstructorId = instructor.Id,
+            Instructor = instructor,
+        };
+
+        // Create irregular students with enrollments
+        var studentUser1 = new IdentityUser
+        {
+            Id = $"student-{instructorId}-1",
+            UserName = $"student{instructorId}1@example.com",
+            NormalizedUserName = $"STUDENT{instructorId}1@EXAMPLE.COM",
+            Email = $"student{instructorId}1@example.com",
+            NormalizedEmail = $"STUDENT{instructorId}1@EXAMPLE.COM",
+        };
+
+        var studentUser2 = new IdentityUser
+        {
+            Id = $"student-{instructorId}-2",
+            UserName = $"student{instructorId}2@example.com",
+            NormalizedUserName = $"STUDENT{instructorId}2@EXAMPLE.COM",
+            Email = $"student{instructorId}2@example.com",
+            NormalizedEmail = $"STUDENT{instructorId}2@EXAMPLE.COM",
+        };
+
+        var studentUser3 = new IdentityUser
+        {
+            Id = $"student-{instructorId}-3",
+            UserName = $"student{instructorId}3@example.com",
+            NormalizedUserName = $"STUDENT{instructorId}3@EXAMPLE.COM",
+            Email = $"student{instructorId}3@example.com",
+            NormalizedEmail = $"STUDENT{instructorId}3@EXAMPLE.COM",
+        };
+
+        var student1 = new Student
+        {
+            Id = instructorId * 1000 + 1,
+            Firstname = "Emma",
+            Lastname = "Wilson",
+            UserId = studentUser1.Id,
+            User = studentUser1,
+            SectionId = section.Id,
+            Section = section,
+            IsRegular = false,
+            IsDeleted = false,
+        };
+
+        var student2 = new Student
+        {
+            Id = instructorId * 1000 + 2,
+            Firstname = "Oliver",
+            Lastname = "Martinez",
+            UserId = studentUser2.Id,
+            User = studentUser2,
+            SectionId = section.Id,
+            Section = section,
+            IsRegular = false,
+            IsDeleted = false,
+        };
+
+        var student3 = new Student
+        {
+            Id = instructorId * 1000 + 3,
+            Firstname = "Sophia",
+            Lastname = "Garcia",
+            UserId = studentUser3.Id,
+            User = studentUser3,
+            SectionId = section.Id,
+            Section = section,
+            IsRegular = true,
+            IsDeleted = false,
+        };
+
+        var enrollment1 = new StudentEnrollment
+        {
+            Id = instructorId * 10000 + 1,
+            StudentId = student1.Id,
+            Student = student1,
+            SectionId = section.Id,
+            Section = section,
+            SubjectId = subject.Id,
+            Subject = subject,
+            IsActive = true,
+            EnrollmentType = "Irregular",
+        };
+
+        var enrollment2 = new StudentEnrollment
+        {
+            Id = instructorId * 10000 + 2,
+            StudentId = student2.Id,
+            Student = student2,
+            SectionId = section.Id,
+            Section = section,
+            SubjectId = subject.Id,
+            Subject = subject,
+            IsActive = true,
+            EnrollmentType = "Retake",
+        };
+
+        var enrollment3 = new StudentEnrollment
+        {
+            Id = instructorId * 10000 + 3,
+            StudentId = student3.Id,
+            Student = student3,
+            SectionId = section.Id,
+            Section = section,
+            SubjectId = subject.Id,
+            Subject = subject,
+            IsActive = true,
+            EnrollmentType = "Regular",
+        };
+
+        _context.Users.AddRange(user, studentUser1, studentUser2, studentUser3);
+        _context.Courses.Add(course);
+        _context.Sections.Add(section);
+        _context.Subjects.Add(subject);
+        _context.Classrooms.Add(classroom);
+        _context.Instructors.Add(instructor);
+        _context.Schedules.Add(schedule);
+        _context.Students.AddRange(student1, student2, student3);
+        _context.StudentEnrollments.AddRange(enrollment1, enrollment2, enrollment3);
+
+        await _context.SaveChangesAsync();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+}

--- a/attendance.testproject/Services_Testing/InstructorServiceTest.cs
+++ b/attendance.testproject/Services_Testing/InstructorServiceTest.cs
@@ -2171,6 +2171,158 @@ public class InstructorServiceTest
     }
 
     [Fact]
+    public async Task GetInstructorStudentDetailAsync_AdditionalEnrollmentForDifferentSubject_ThrowsEntityUnauthorizedException()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        const int studentId = 1;
+        var instructor = new Instructor { Id = instructorId, Firstname = "John", Lastname = "Doe", UserId = userId };
+
+        var course = new Course { Id = 1, Uuid = Guid.NewGuid(), Name = "Computer Science" };
+        var homeSection = new Section { Id = 1, Uuid = Guid.NewGuid(), Name = "CS-3A", CourseId = 1, Course = course };
+        var handledSection = new Section { Id = 2, Uuid = Guid.NewGuid(), Name = "CS-3B", CourseId = 1, Course = course };
+
+        var student = new Student
+        {
+            Id = studentId,
+            Uuid = Guid.NewGuid(),
+            Firstname = "Alice",
+            Lastname = "Smith",
+            SectionId = homeSection.Id,
+            IsRegular = false,
+            IsDeleted = false,
+            Section = homeSection,
+            AdditionalEnrollments = new List<StudentEnrollment>
+            {
+                new()
+                {
+                    Id = 1,
+                    Uuid = Guid.NewGuid(),
+                    StudentId = studentId,
+                    SectionId = handledSection.Id,
+                    Section = handledSection,
+                    SubjectId = 2,
+                    Subject = new Subject { Id = 2, Name = "Algorithms", Code = "CS302" },
+                    IsActive = true,
+                    EnrollmentType = EnrollmentTypeConstants.Irregular
+                }
+            }
+        };
+
+        var instructorSchedules = new List<Schedules>
+        {
+            new()
+            {
+                Id = 1,
+                Uuid = Guid.NewGuid(),
+                SubjectId = 1,
+                Subject = new Subject { Id = 1, Name = "Data Structures", Code = "CS301" },
+                SectionId = handledSection.Id,
+                Section = handledSection,
+                ClassroomId = 1,
+                Classroom = new Classroom { Id = 1, Name = "Room 101" },
+                InstructorId = instructorId,
+                DayOfWeek = "Monday",
+                TimeIn = new TimeOnly(9, 0),
+                TimeOut = new TimeOnly(11, 0)
+            }
+        };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.GetStudentWithDetailsAsync(studentId)).ReturnsAsync(student);
+        _mockInstructorRepository.Setup(r => r.IsInstructorHandlingSectionAsync(instructorId, student.SectionId)).ReturnsAsync(false);
+        _mockScheduleRepository.Setup(r => r.GetSchedulesByInstructorIdAsync(instructorId)).ReturnsAsync(instructorSchedules);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityUnauthorizedException>(
+            () => _service.GetInstructorStudentDetailAsync(_testUserPrincipal, studentId));
+        Assert.Equal("Student", exception.EntityName);
+    }
+
+    [Fact]
+    public async Task GetInstructorStudentDetailAsync_AdditionalEnrollmentForMatchingSubject_ReturnsStudentDetailDto()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        const int studentId = 1;
+        var instructor = new Instructor { Id = instructorId, Firstname = "John", Lastname = "Doe", UserId = userId };
+
+        var course = new Course { Id = 1, Uuid = Guid.NewGuid(), Name = "Computer Science" };
+        var homeSection = new Section { Id = 1, Uuid = Guid.NewGuid(), Name = "CS-3A", CourseId = 1, Course = course };
+        var handledSection = new Section { Id = 2, Uuid = Guid.NewGuid(), Name = "CS-3B", CourseId = 1, Course = course };
+        var matchingSubject = new Subject { Id = 2, Name = "Algorithms", Code = "CS302" };
+
+        var student = new Student
+        {
+            Id = studentId,
+            Uuid = Guid.NewGuid(),
+            Firstname = "Alice",
+            Lastname = "Smith",
+            SectionId = homeSection.Id,
+            IsRegular = false,
+            IsDeleted = false,
+            Section = homeSection,
+            AdditionalEnrollments = new List<StudentEnrollment>
+            {
+                new()
+                {
+                    Id = 1,
+                    Uuid = Guid.NewGuid(),
+                    StudentId = studentId,
+                    SectionId = handledSection.Id,
+                    Section = handledSection,
+                    SubjectId = matchingSubject.Id,
+                    Subject = matchingSubject,
+                    IsActive = true,
+                    EnrollmentType = EnrollmentTypeConstants.Irregular
+                }
+            }
+        };
+
+        var instructorSchedules = new List<Schedules>
+        {
+            new()
+            {
+                Id = 1,
+                Uuid = Guid.NewGuid(),
+                SubjectId = matchingSubject.Id,
+                Subject = matchingSubject,
+                SectionId = handledSection.Id,
+                Section = handledSection,
+                ClassroomId = 1,
+                Classroom = new Classroom { Id = 1, Name = "Room 101" },
+                InstructorId = instructorId,
+                DayOfWeek = "Monday",
+                TimeIn = new TimeOnly(9, 0),
+                TimeOut = new TimeOnly(11, 0)
+            }
+        };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.GetStudentWithDetailsAsync(studentId)).ReturnsAsync(student);
+        _mockInstructorRepository.Setup(r => r.IsInstructorHandlingSectionAsync(instructorId, student.SectionId)).ReturnsAsync(false);
+        _mockScheduleRepository.Setup(r => r.GetSchedulesByInstructorIdAsync(instructorId)).ReturnsAsync(instructorSchedules);
+        _mockInstructorRepository.Setup(r => r.GetHandledClassesBySectionAndInstructorAsync(student.SectionId, instructorId))
+            .ReturnsAsync(new List<Schedules>());
+        _mockInstructorRepository.Setup(r => r.GetStudentAttendanceForInstructorSubjectsAsync(studentId, instructorId))
+            .ReturnsAsync(new List<AttendanceRecord>());
+
+        // Act
+        var result = await _service.GetInstructorStudentDetailAsync(_testUserPrincipal, studentId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Enrollments);
+        Assert.Equal(matchingSubject.Id, result.Enrollments[0].SubjectId);
+        Assert.Equal(handledSection.Id, result.Enrollments[0].SectionId);
+        Assert.Equal(EnrollmentTypeConstants.Irregular, result.Enrollments[0].EnrollmentType);
+    }
+
+    [Fact]
     public async Task GetInstructorStudentDetailAsync_StudentNotFound_ThrowsEntityNotFoundException()
     {
         // Arrange

--- a/attendance.testproject/Services_Testing/InstructorServiceTest.cs
+++ b/attendance.testproject/Services_Testing/InstructorServiceTest.cs
@@ -21,6 +21,7 @@ namespace attendance.testproject.Services_Testing;
 public class InstructorServiceTest
 {
     private readonly Mock<IInstructorRepository> _mockInstructorRepository;
+    private readonly Mock<ISectionRepository> _mockSectionRepository;
     private readonly Mock<IScheduleRepository> _mockScheduleRepository;
     private readonly Mock<IUserContextService> _mockUserContextService;
     private readonly Mock<ILogger<InstructorService>> _mockLogger;
@@ -30,12 +31,18 @@ public class InstructorServiceTest
     public InstructorServiceTest()
     {
         _mockInstructorRepository = new Mock<IInstructorRepository>();
+        _mockSectionRepository = new Mock<ISectionRepository>();
         _mockScheduleRepository = new Mock<IScheduleRepository>();
         _mockUserContextService = new Mock<IUserContextService>();
         _mockLogger = new Mock<ILogger<InstructorService>>();
 
+        _mockSectionRepository
+            .Setup(r => r.GetSectionByIdAsync(It.IsAny<int>()))
+            .ReturnsAsync((int id) => new Section { Id = id });
+
         _service = new InstructorService(
             _mockInstructorRepository.Object,
+            _mockSectionRepository.Object,
             _mockScheduleRepository.Object,
             _mockUserContextService.Object,
             _mockLogger.Object
@@ -56,10 +63,11 @@ public class InstructorServiceTest
     public void Constructor_NullDependency_ThrowsArgumentNullException()
     {
         // Arrange & Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new InstructorService(null!, _mockScheduleRepository.Object, _mockUserContextService.Object, _mockLogger.Object));
-        Assert.Throws<ArgumentNullException>(() => new InstructorService(_mockInstructorRepository.Object, null!, _mockUserContextService.Object, _mockLogger.Object));
-        Assert.Throws<ArgumentNullException>(() => new InstructorService(_mockInstructorRepository.Object, _mockScheduleRepository.Object, null!, _mockLogger.Object));
-        Assert.Throws<ArgumentNullException>(() => new InstructorService(_mockInstructorRepository.Object, _mockScheduleRepository.Object, _mockUserContextService.Object, null!));
+        Assert.Throws<ArgumentNullException>(() => new InstructorService(null!, _mockSectionRepository.Object, _mockScheduleRepository.Object, _mockUserContextService.Object, _mockLogger.Object));
+        Assert.Throws<ArgumentNullException>(() => new InstructorService(_mockInstructorRepository.Object, null!, _mockScheduleRepository.Object, _mockUserContextService.Object, _mockLogger.Object));
+        Assert.Throws<ArgumentNullException>(() => new InstructorService(_mockInstructorRepository.Object, _mockSectionRepository.Object, null!, _mockUserContextService.Object, _mockLogger.Object));
+        Assert.Throws<ArgumentNullException>(() => new InstructorService(_mockInstructorRepository.Object, _mockSectionRepository.Object, _mockScheduleRepository.Object, null!, _mockLogger.Object));
+        Assert.Throws<ArgumentNullException>(() => new InstructorService(_mockInstructorRepository.Object, _mockSectionRepository.Object, _mockScheduleRepository.Object, _mockUserContextService.Object, null!));
     }
 
     #endregion
@@ -1952,7 +1960,7 @@ public class InstructorServiceTest
         // Arrange
         const string userId = "test-user-id";
         const int instructorId = 1;
-        const int sectionId = 999;
+        const int sectionId = 1;
         var instructor = new Instructor { Id = instructorId, Firstname = "John", Lastname = "Doe", UserId = userId };
 
         _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
@@ -1963,6 +1971,27 @@ public class InstructorServiceTest
         var exception = await Assert.ThrowsAsync<EntityUnauthorizedException>(
             () => _service.GetInstructorSectionDetailAsync(_testUserPrincipal, sectionId));
         Assert.Equal("Section", exception.EntityName);
+    }
+
+    [Fact]
+    public async Task GetInstructorSectionDetailAsync_SectionNotFound_ThrowsEntityNotFoundException()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        const int sectionId = 999;
+        var instructor = new Instructor { Id = instructorId, Firstname = "John", Lastname = "Doe", UserId = userId };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockSectionRepository.Setup(r => r.GetSectionByIdAsync(sectionId)).ReturnsAsync((Section?)null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<int>>(
+            () => _service.GetInstructorSectionDetailAsync(_testUserPrincipal, sectionId));
+        Assert.Equal("Section", exception.EntityName);
+        Assert.Equal(sectionId, exception.Key);
+        _mockInstructorRepository.Verify(r => r.IsInstructorHandlingSectionAsync(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
     }
 
     [Fact]

--- a/attendance.testproject/Services_Testing/InstructorServiceTest.cs
+++ b/attendance.testproject/Services_Testing/InstructorServiceTest.cs
@@ -1689,7 +1689,15 @@ public class InstructorServiceTest
         var instructor = new Instructor { Id = instructorId, Firstname = "John", Lastname = "Doe", UserId = userId };
 
         var course = new Course { Id = 1, Uuid = Guid.NewGuid(), Name = "Computer Science" };
-        var section1 = new Section { Id = 1, Uuid = Guid.NewGuid(), Name = "CS-3A", CourseId = 1, Course = course };
+        var section1 = new Section
+        {
+            Id = 1,
+            Uuid = Guid.NewGuid(),
+            Name = "CS-3A",
+            CourseId = 1,
+            Course = course,
+            StudentEnrollments = new List<StudentEnrollment>()
+        };
         var section2 = new Section { Id = 2, Uuid = Guid.NewGuid(), Name = "CS-3B", CourseId = 1, Course = course };
 
         var subject = new Subject { Id = 1, Uuid = Guid.NewGuid(), Name = "Data Structures", Code = "CS301" };
@@ -1711,6 +1719,17 @@ public class InstructorServiceTest
 
         var student1 = new Student { Id = 1, Uuid = Guid.NewGuid(), Firstname = "Alice", Lastname = "Smith", SectionId = 1, IsDeleted = false };
         var student2 = new Student { Id = 2, Uuid = Guid.NewGuid(), Firstname = "Bob", Lastname = "Johnson", SectionId = 2, IsDeleted = false };
+        var irregularStudent = new Student { Id = 3, Uuid = Guid.NewGuid(), Firstname = "Cara", Lastname = "Lopez", SectionId = 99, IsDeleted = false };
+
+        section1.StudentEnrollments.Add(new StudentEnrollment
+        {
+            StudentId = irregularStudent.Id,
+            SectionId = section1.Id,
+            SubjectId = schedule1.SubjectId,
+            Student = irregularStudent,
+            IsActive = true,
+            EnrollmentType = EnrollmentTypeConstants.Irregular
+        });
 
         _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
         _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
@@ -1735,12 +1754,91 @@ public class InstructorServiceTest
         var overview1 = result.First(s => s.SectionId == 1);
         Assert.Equal("CS-3A", overview1.SectionName);
         Assert.Equal(2, overview1.HandledClassCount);
-        Assert.Equal(1, overview1.UniqueStudentCount);
+        Assert.Equal(2, overview1.UniqueStudentCount);
 
         var overview2 = result.First(s => s.SectionId == 2);
         Assert.Equal("CS-3B", overview2.SectionName);
         Assert.Equal(0, overview2.HandledClassCount);
-        Assert.Equal(1, overview2.UniqueStudentCount);
+        Assert.Equal(0, overview2.UniqueStudentCount);
+    }
+
+    [Fact]
+    public async Task GetInstructorSectionDetailAsync_MultipleHandledClasses_LoadsRegularStudentsOnce()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        const int sectionId = 1;
+
+        var instructor = new Instructor { Id = instructorId, Firstname = "John", Lastname = "Doe", UserId = userId };
+        var course = new Course { Id = 1, Uuid = Guid.NewGuid(), Name = "Computer Science" };
+        var section = new Section
+        {
+            Id = sectionId,
+            Uuid = Guid.NewGuid(),
+            Name = "CS-3A",
+            CourseId = 1,
+            Course = course,
+            StudentEnrollments = new List<StudentEnrollment>()
+        };
+
+        var classroom = new Classroom { Id = 1, Uuid = Guid.NewGuid(), Name = "Room 101" };
+        var subject1 = new Subject { Id = 1, Uuid = Guid.NewGuid(), Name = "Data Structures", Code = "CS301" };
+        var subject2 = new Subject { Id = 2, Uuid = Guid.NewGuid(), Name = "Algorithms", Code = "CS302" };
+        var regularStudent = new Student { Id = 1, Uuid = Guid.NewGuid(), Firstname = "Alice", Lastname = "Smith", SectionId = sectionId, IsDeleted = false };
+
+        var schedules = new List<Schedules>
+        {
+            new()
+            {
+                Id = 1,
+                Uuid = Guid.NewGuid(),
+                InstructorId = instructorId,
+                SectionId = sectionId,
+                SubjectId = subject1.Id,
+                ClassroomId = classroom.Id,
+                DayOfWeek = "Monday",
+                TimeIn = TimeOnly.FromTimeSpan(TimeSpan.FromHours(8)),
+                TimeOut = TimeOnly.FromTimeSpan(TimeSpan.FromHours(10)),
+                Section = section,
+                Subject = subject1,
+                Classroom = classroom,
+                Instructor = instructor
+            },
+            new()
+            {
+                Id = 2,
+                Uuid = Guid.NewGuid(),
+                InstructorId = instructorId,
+                SectionId = sectionId,
+                SubjectId = subject2.Id,
+                ClassroomId = classroom.Id,
+                DayOfWeek = "Tuesday",
+                TimeIn = TimeOnly.FromTimeSpan(TimeSpan.FromHours(10)),
+                TimeOut = TimeOnly.FromTimeSpan(TimeSpan.FromHours(12)),
+                Section = section,
+                Subject = subject2,
+                Classroom = classroom,
+                Instructor = instructor
+            }
+        };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.IsInstructorHandlingSectionAsync(instructorId, sectionId)).ReturnsAsync(true);
+        _mockInstructorRepository.Setup(r => r.GetHandledClassesBySectionAndInstructorAsync(sectionId, instructorId))
+            .ReturnsAsync(schedules);
+        _mockInstructorRepository.Setup(r => r.GetRegularStudentsBySectionIdAsync(sectionId))
+            .ReturnsAsync(new List<Student> { regularStudent });
+        _mockInstructorRepository.Setup(r => r.GetHomeSectionStudentsAsync(sectionId))
+            .ReturnsAsync(new List<Student> { regularStudent });
+
+        // Act
+        var result = await _service.GetInstructorSectionDetailAsync(_testUserPrincipal, sectionId);
+
+        // Assert
+        Assert.Equal(2, result.HandledClassCount);
+        _mockInstructorRepository.Verify(r => r.GetRegularStudentsBySectionIdAsync(sectionId), Times.Once);
     }
 
     [Fact]

--- a/attendance.testproject/Services_Testing/InstructorServiceTest.cs
+++ b/attendance.testproject/Services_Testing/InstructorServiceTest.cs
@@ -1677,4 +1677,501 @@ public class InstructorServiceTest
     }
 
     #endregion
+
+    #region GetInstructorSectionsOverviewAsync Tests
+
+    [Fact]
+    public async Task GetInstructorSectionsOverviewAsync_Success_ReturnsOverviewDtos()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        var instructor = new Instructor { Id = instructorId, Firstname = "John", Lastname = "Doe", UserId = userId };
+
+        var course = new Course { Id = 1, Uuid = Guid.NewGuid(), Name = "Computer Science" };
+        var section1 = new Section { Id = 1, Uuid = Guid.NewGuid(), Name = "CS-3A", CourseId = 1, Course = course };
+        var section2 = new Section { Id = 2, Uuid = Guid.NewGuid(), Name = "CS-3B", CourseId = 1, Course = course };
+
+        var subject = new Subject { Id = 1, Uuid = Guid.NewGuid(), Name = "Data Structures", Code = "CS301" };
+        var classroom = new Classroom { Id = 1, Uuid = Guid.NewGuid(), Name = "Room 101" };
+
+        var schedule1 = new Schedules
+        {
+            Id = 1, Uuid = Guid.NewGuid(), InstructorId = instructorId, SectionId = 1, SubjectId = 1,
+            DayOfWeek = "Monday", TimeIn = TimeOnly.FromTimeSpan(TimeSpan.FromHours(8)), TimeOut = TimeOnly.FromTimeSpan(TimeSpan.FromHours(10)),
+            Section = section1, Subject = subject, Classroom = classroom, Instructor = instructor
+        };
+
+        var schedule2 = new Schedules
+        {
+            Id = 2, Uuid = Guid.NewGuid(), InstructorId = instructorId, SectionId = 1, SubjectId = 2,
+            DayOfWeek = "Tuesday", TimeIn = TimeOnly.FromTimeSpan(TimeSpan.FromHours(10)), TimeOut = TimeOnly.FromTimeSpan(TimeSpan.FromHours(12)),
+            Section = section1, Subject = subject, Classroom = classroom, Instructor = instructor
+        };
+
+        var student1 = new Student { Id = 1, Uuid = Guid.NewGuid(), Firstname = "Alice", Lastname = "Smith", SectionId = 1, IsDeleted = false };
+        var student2 = new Student { Id = 2, Uuid = Guid.NewGuid(), Firstname = "Bob", Lastname = "Johnson", SectionId = 2, IsDeleted = false };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.GetHandledSectionsByInstructorIdAsync(instructorId))
+            .ReturnsAsync(new List<Section> { section1, section2 });
+        _mockInstructorRepository.Setup(r => r.GetHandledClassesBySectionAndInstructorAsync(1, instructorId))
+            .ReturnsAsync(new List<Schedules> { schedule1, schedule2 });
+        _mockInstructorRepository.Setup(r => r.GetHandledClassesBySectionAndInstructorAsync(2, instructorId))
+            .ReturnsAsync(new List<Schedules>());
+        _mockInstructorRepository.Setup(r => r.GetRegularStudentsBySectionIdAsync(1))
+            .ReturnsAsync(new List<Student> { student1 });
+        _mockInstructorRepository.Setup(r => r.GetRegularStudentsBySectionIdAsync(2))
+            .ReturnsAsync(new List<Student> { student2 });
+
+        // Act
+        var result = await _service.GetInstructorSectionsOverviewAsync(_testUserPrincipal);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+
+        var overview1 = result.First(s => s.SectionId == 1);
+        Assert.Equal("CS-3A", overview1.SectionName);
+        Assert.Equal(2, overview1.HandledClassCount);
+        Assert.Equal(1, overview1.UniqueStudentCount);
+
+        var overview2 = result.First(s => s.SectionId == 2);
+        Assert.Equal("CS-3B", overview2.SectionName);
+        Assert.Equal(0, overview2.HandledClassCount);
+        Assert.Equal(1, overview2.UniqueStudentCount);
+    }
+
+    [Fact]
+    public async Task GetInstructorSectionsOverviewAsync_MissingUserId_ThrowsEntityNotFoundException()
+    {
+        // Arrange
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync((string?)null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<string>>(
+            () => _service.GetInstructorSectionsOverviewAsync(_testUserPrincipal));
+        Assert.Equal("User", exception.EntityName);
+    }
+
+    [Fact]
+    public async Task GetInstructorSectionsOverviewAsync_InstructorNotFound_ThrowsEntityNotFoundException()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync((Instructor?)null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<string>>(
+            () => _service.GetInstructorSectionsOverviewAsync(_testUserPrincipal));
+        Assert.Equal("Instructor", exception.EntityName);
+    }
+
+    [Fact]
+    public async Task GetInstructorSectionsOverviewAsync_RepositoryFailure_WrapsInEntityServiceException()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        var instructor = new Instructor { Id = instructorId, Firstname = "John", Lastname = "Doe", UserId = userId };
+        var expectedException = new InvalidOperationException("Database error");
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.GetHandledSectionsByInstructorIdAsync(instructorId))
+            .ThrowsAsync(expectedException);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.GetInstructorSectionsOverviewAsync(_testUserPrincipal));
+
+        // Assert
+        Assert.Equal("Instructor", exception.EntityName);
+        Assert.Equal("GetInstructorSectionsOverview", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    #endregion
+
+    #region GetInstructorSectionDetailAsync Tests
+
+    [Fact]
+    public async Task GetInstructorSectionDetailAsync_Success_ReturnsSectionDetailDto()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        const int sectionId = 1;
+        var instructor = new Instructor { Id = instructorId, Firstname = "John", Lastname = "Doe", UserId = userId };
+
+        var course = new Course { Id = 1, Uuid = Guid.NewGuid(), Name = "Computer Science" };
+        var section = new Section
+        {
+            Id = sectionId, Uuid = Guid.NewGuid(), Name = "CS-3A", CourseId = 1, Course = course,
+            StudentEnrollments = new List<StudentEnrollment>()
+        };
+
+        var subject = new Subject { Id = 1, Uuid = Guid.NewGuid(), Name = "Data Structures", Code = "CS301" };
+        var classroom = new Classroom { Id = 1, Uuid = Guid.NewGuid(), Name = "Room 101" };
+
+        var schedule = new Schedules
+        {
+            Id = 1, Uuid = Guid.NewGuid(), InstructorId = instructorId, SectionId = sectionId, SubjectId = 1, ClassroomId = 1,
+            DayOfWeek = "Monday", TimeIn = TimeOnly.FromTimeSpan(TimeSpan.FromHours(8)), TimeOut = TimeOnly.FromTimeSpan(TimeSpan.FromHours(10)),
+            Section = section, Subject = subject, Classroom = classroom, Instructor = instructor
+        };
+
+        var regularStudent = new Student { Id = 1, Uuid = Guid.NewGuid(), Firstname = "Alice", Lastname = "Smith", SectionId = sectionId, IsDeleted = false };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.IsInstructorHandlingSectionAsync(instructorId, sectionId)).ReturnsAsync(true);
+        _mockInstructorRepository.Setup(r => r.GetHandledClassesBySectionAndInstructorAsync(sectionId, instructorId))
+            .ReturnsAsync(new List<Schedules> { schedule });
+        _mockInstructorRepository.Setup(r => r.GetRegularStudentsBySectionIdAsync(sectionId))
+            .ReturnsAsync(new List<Student> { regularStudent });
+        _mockInstructorRepository.Setup(r => r.GetHomeSectionStudentsAsync(sectionId))
+            .ReturnsAsync(new List<Student> { regularStudent });
+
+        // Act
+        var result = await _service.GetInstructorSectionDetailAsync(_testUserPrincipal, sectionId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(sectionId, result.SectionId);
+        Assert.Equal("CS-3A", result.SectionName);
+        Assert.Equal(1, result.HandledClassCount);
+        Assert.Single(result.HandledClasses);
+        Assert.Equal("Data Structures", result.HandledClasses.First().SubjectName);
+        Assert.Single(result.HomeSectionStudents);
+    }
+
+    [Fact]
+    public async Task GetInstructorSectionDetailAsync_NotHandlingSection_ThrowsEntityUnauthorizedException()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        const int sectionId = 999;
+        var instructor = new Instructor { Id = instructorId, Firstname = "John", Lastname = "Doe", UserId = userId };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.IsInstructorHandlingSectionAsync(instructorId, sectionId)).ReturnsAsync(false);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityUnauthorizedException>(
+            () => _service.GetInstructorSectionDetailAsync(_testUserPrincipal, sectionId));
+        Assert.Equal("Section", exception.EntityName);
+    }
+
+    [Fact]
+    public async Task GetInstructorSectionDetailAsync_MissingUserId_ThrowsEntityNotFoundException()
+    {
+        // Arrange
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync((string?)null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<string>>(
+            () => _service.GetInstructorSectionDetailAsync(_testUserPrincipal, 1));
+        Assert.Equal("User", exception.EntityName);
+    }
+
+    [Fact]
+    public async Task GetInstructorSectionDetailAsync_InstructorNotFound_ThrowsEntityNotFoundException()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync((Instructor?)null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<string>>(
+            () => _service.GetInstructorSectionDetailAsync(_testUserPrincipal, 1));
+        Assert.Equal("Instructor", exception.EntityName);
+    }
+
+    [Fact]
+    public async Task GetInstructorSectionDetailAsync_RepositoryFailure_WrapsInEntityServiceException()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        const int sectionId = 1;
+        var instructor = new Instructor { Id = instructorId, Firstname = "John", Lastname = "Doe", UserId = userId };
+        var expectedException = new InvalidOperationException("Database error");
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.IsInstructorHandlingSectionAsync(instructorId, sectionId)).ReturnsAsync(true);
+        _mockInstructorRepository.Setup(r => r.GetHandledClassesBySectionAndInstructorAsync(sectionId, instructorId))
+            .ThrowsAsync(expectedException);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.GetInstructorSectionDetailAsync(_testUserPrincipal, sectionId));
+
+        // Assert
+        Assert.Equal("Instructor", exception.EntityName);
+        Assert.Equal($"GetInstructorSectionDetail: {sectionId}", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    #endregion
+
+    #region GetInstructorStudentDetailAsync Tests
+
+    [Fact]
+    public async Task GetInstructorStudentDetailAsync_Success_ReturnsStudentDetailDto()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        const int studentId = 1;
+        var instructor = new Instructor { Id = instructorId, Firstname = "John", Lastname = "Doe", UserId = userId };
+
+        var course = new Course { Id = 1, Uuid = Guid.NewGuid(), Name = "Computer Science" };
+        var section = new Section { Id = 1, Uuid = Guid.NewGuid(), Name = "CS-3A", CourseId = 1, Course = course };
+
+        var student = new Student
+        {
+            Id = studentId, Uuid = Guid.NewGuid(), Firstname = "Alice", Lastname = "Smith",
+            SectionId = 1, IsRegular = true, IsDeleted = false, Section = section,
+            AdditionalEnrollments = new List<StudentEnrollment>()
+        };
+
+        var attendanceRecord = new AttendanceRecord
+        {
+            Id = 1, StudentId = studentId, SessionId = 1, Status = "Present",
+            CheckInTime = DateTime.UtcNow,
+            Session = new Session
+            {
+                Id = 1, Schedule = new Schedules
+                {
+                    Id = 1, InstructorId = instructorId, Subject = new Subject { Id = 1, Name = "Data Structures", Code = "CS301" }
+                }
+            }
+        };
+
+        var instructorSchedules = new List<Schedules>
+        {
+            new()
+            {
+                Id = 1, Uuid = Guid.NewGuid(),
+                SubjectId = 1, Subject = new Subject { Id = 1, Name = "Data Structures", Code = "CS301" },
+                SectionId = section.Id, Section = section,
+                ClassroomId = 1, Classroom = new Classroom { Id = 1, Name = "Room 101" },
+                InstructorId = instructorId,
+                DayOfWeek = "Monday", TimeIn = new TimeOnly(9, 0), TimeOut = new TimeOnly(11, 0)
+            }
+        };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.GetStudentWithDetailsAsync(studentId)).ReturnsAsync(student);
+        _mockInstructorRepository.Setup(r => r.IsInstructorHandlingSectionAsync(instructorId, student.SectionId)).ReturnsAsync(true);
+        _mockInstructorRepository.Setup(r => r.GetHandledClassesBySectionAndInstructorAsync(student.SectionId, instructorId))
+            .ReturnsAsync(instructorSchedules);
+        _mockInstructorRepository.Setup(r => r.GetStudentAttendanceForInstructorSubjectsAsync(studentId, instructorId))
+            .ReturnsAsync(new List<AttendanceRecord> { attendanceRecord });
+
+        // Act
+        var result = await _service.GetInstructorStudentDetailAsync(_testUserPrincipal, studentId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(studentId, result.StudentId);
+        Assert.Equal("Alice", result.Firstname);
+        Assert.Equal("Smith", result.Lastname);
+        Assert.Equal(1, result.SectionId);
+        Assert.Equal("CS-3A", result.SectionName);
+        Assert.True(result.IsRegular);
+        Assert.Equal("Regular", result.EnrollmentType);
+        Assert.Single(result.Enrollments);
+        Assert.Equal(1, result.Enrollments[0].SubjectId);
+        Assert.Equal("Data Structures", result.Enrollments[0].SubjectName);
+        Assert.Equal("CS301", result.Enrollments[0].SubjectCode);
+        Assert.Equal("Regular", result.Enrollments[0].EnrollmentType);
+        Assert.Equal(1, result.AttendanceSummary.TotalSessions);
+        Assert.Equal(1, result.AttendanceSummary.PresentCount);
+        Assert.Equal(0, result.AttendanceSummary.AbsentCount);
+        Assert.Equal(0, result.AttendanceSummary.LateCount);
+        Assert.Equal(100.0, result.AttendanceSummary.AttendanceRate);
+    }
+
+    [Fact]
+    public async Task GetInstructorStudentDetailAsync_RegularStudentWithAdditionalEnrollments_ReturnsCombinedEnrollments()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        const int studentId = 1;
+        var instructor = new Instructor { Id = instructorId, Firstname = "John", Lastname = "Doe", UserId = userId };
+
+        var course = new Course { Id = 1, Uuid = Guid.NewGuid(), Name = "Computer Science" };
+        var section = new Section { Id = 1, Uuid = Guid.NewGuid(), Name = "CS-3A", CourseId = 1, Course = course };
+        var otherSection = new Section { Id = 2, Uuid = Guid.NewGuid(), Name = "CS-3B", CourseId = 1, Course = course };
+
+        var student = new Student
+        {
+            Id = studentId, Uuid = Guid.NewGuid(), Firstname = "Alice", Lastname = "Smith",
+            SectionId = section.Id, IsRegular = true, IsDeleted = false, Section = section,
+            AdditionalEnrollments = new List<StudentEnrollment>
+            {
+                new()
+                {
+                    Id = 1, Uuid = Guid.NewGuid(), StudentId = studentId,
+                    SectionId = otherSection.Id, Section = otherSection,
+                    SubjectId = 2, Subject = new Subject { Id = 2, Name = "Algorithms", Code = "CS302" },
+                    IsActive = true, EnrollmentType = EnrollmentTypeConstants.Irregular
+                }
+            }
+        };
+
+        var instructorSchedules = new List<Schedules>
+        {
+            new()
+            {
+                Id = 1, Uuid = Guid.NewGuid(),
+                SubjectId = 1, Subject = new Subject { Id = 1, Name = "Data Structures", Code = "CS301" },
+                SectionId = section.Id, Section = section,
+                ClassroomId = 1, Classroom = new Classroom { Id = 1, Name = "Room 101" },
+                InstructorId = instructorId,
+                DayOfWeek = "Monday", TimeIn = new TimeOnly(9, 0), TimeOut = new TimeOnly(11, 0)
+            }
+        };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.GetStudentWithDetailsAsync(studentId)).ReturnsAsync(student);
+        _mockInstructorRepository.Setup(r => r.IsInstructorHandlingSectionAsync(instructorId, student.SectionId)).ReturnsAsync(true);
+        _mockInstructorRepository.Setup(r => r.GetHandledClassesBySectionAndInstructorAsync(student.SectionId, instructorId))
+            .ReturnsAsync(instructorSchedules);
+        _mockInstructorRepository.Setup(r => r.GetStudentAttendanceForInstructorSubjectsAsync(studentId, instructorId))
+            .ReturnsAsync(new List<AttendanceRecord>());
+
+        // Act
+        var result = await _service.GetInstructorStudentDetailAsync(_testUserPrincipal, studentId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Enrollments.Count);
+
+        var homeEnrollment = result.Enrollments.First(e => e.SubjectId == 1);
+        Assert.Equal("Data Structures", homeEnrollment.SubjectName);
+        Assert.Equal("CS301", homeEnrollment.SubjectCode);
+        Assert.Equal(section.Id, homeEnrollment.SectionId);
+        Assert.Equal("Regular", homeEnrollment.EnrollmentType);
+
+        var additionalEnrollment = result.Enrollments.First(e => e.SubjectId == 2);
+        Assert.Equal("Algorithms", additionalEnrollment.SubjectName);
+        Assert.Equal("CS302", additionalEnrollment.SubjectCode);
+        Assert.Equal(otherSection.Id, additionalEnrollment.SectionId);
+        Assert.Equal(EnrollmentTypeConstants.Irregular, additionalEnrollment.EnrollmentType);
+    }
+
+    [Fact]
+    public async Task GetInstructorStudentDetailAsync_StudentNotFound_ThrowsEntityNotFoundException()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        const int studentId = 999;
+        var instructor = new Instructor { Id = instructorId, Firstname = "John", Lastname = "Doe", UserId = userId };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.GetStudentWithDetailsAsync(studentId)).ReturnsAsync((Student?)null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<int>>(
+            () => _service.GetInstructorStudentDetailAsync(_testUserPrincipal, studentId));
+        Assert.Equal("Student", exception.EntityName);
+        Assert.Equal(studentId, exception.Key);
+    }
+
+    [Fact]
+    public async Task GetInstructorStudentDetailAsync_NotVisibleToInstructor_ThrowsEntityUnauthorizedException()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        const int studentId = 1;
+        var instructor = new Instructor { Id = instructorId, Firstname = "John", Lastname = "Doe", UserId = userId };
+
+        var course = new Course { Id = 1, Uuid = Guid.NewGuid(), Name = "Computer Science" };
+        var section = new Section { Id = 1, Uuid = Guid.NewGuid(), Name = "CS-3A", CourseId = 1, Course = course };
+
+        var student = new Student
+        {
+            Id = studentId, Uuid = Guid.NewGuid(), Firstname = "Alice", Lastname = "Smith",
+            SectionId = 1, IsRegular = true, IsDeleted = false, Section = section,
+            AdditionalEnrollments = new List<StudentEnrollment>()
+        };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.GetStudentWithDetailsAsync(studentId)).ReturnsAsync(student);
+        _mockInstructorRepository.Setup(r => r.IsInstructorHandlingSectionAsync(instructorId, student.SectionId)).ReturnsAsync(false);
+        _mockScheduleRepository.Setup(r => r.GetSchedulesByInstructorIdAsync(instructorId)).ReturnsAsync(new List<Schedules>());
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityUnauthorizedException>(
+            () => _service.GetInstructorStudentDetailAsync(_testUserPrincipal, studentId));
+        Assert.Equal("Student", exception.EntityName);
+    }
+
+    [Fact]
+    public async Task GetInstructorStudentDetailAsync_MissingUserId_ThrowsEntityNotFoundException()
+    {
+        // Arrange
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync((string?)null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<string>>(
+            () => _service.GetInstructorStudentDetailAsync(_testUserPrincipal, 1));
+        Assert.Equal("User", exception.EntityName);
+    }
+
+    [Fact]
+    public async Task GetInstructorStudentDetailAsync_InstructorNotFound_ThrowsEntityNotFoundException()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync((Instructor?)null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<string>>(
+            () => _service.GetInstructorStudentDetailAsync(_testUserPrincipal, 1));
+        Assert.Equal("Instructor", exception.EntityName);
+    }
+
+    [Fact]
+    public async Task GetInstructorStudentDetailAsync_RepositoryFailure_WrapsInEntityServiceException()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        const int studentId = 1;
+        var instructor = new Instructor { Id = instructorId, Firstname = "John", Lastname = "Doe", UserId = userId };
+        var expectedException = new InvalidOperationException("Database error");
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.GetStudentWithDetailsAsync(studentId)).ThrowsAsync(expectedException);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.GetInstructorStudentDetailAsync(_testUserPrincipal, studentId));
+
+        // Assert
+        Assert.Equal("Instructor", exception.EntityName);
+        Assert.Equal($"GetInstructorStudentDetail: {studentId}", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    #endregion
 }

--- a/attendance.testproject/Services_Testing/InstructorServiceTest.cs
+++ b/attendance.testproject/Services_Testing/InstructorServiceTest.cs
@@ -1152,6 +1152,8 @@ public class InstructorServiceTest
         _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
         _mockInstructorRepository.Setup(r => r.GetSchedulesWithRelatedDataByInstructorIdAsync(instructorId))
             .ReturnsAsync(schedules);
+        _mockInstructorRepository.Setup(r => r.GetRegularStudentsBySectionIdAsync(section.Id))
+            .ReturnsAsync(new List<Student> { student1 });
 
         // Act
         var result = await _service.GetSectionsWithStudentsByInstructorAsync(_testUserPrincipal);
@@ -1290,6 +1292,8 @@ public class InstructorServiceTest
         _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
         _mockInstructorRepository.Setup(r => r.GetSchedulesWithRelatedDataByInstructorIdAsync(instructorId))
             .ReturnsAsync(new List<Schedules> { schedule });
+        _mockInstructorRepository.Setup(r => r.GetRegularStudentsBySectionIdAsync(section.Id))
+            .ReturnsAsync(new List<Student> { regularStudent });
 
         // Act
         var result = await _service.GetSectionsWithStudentsByInstructorAsync(_testUserPrincipal);
@@ -1453,6 +1457,8 @@ public class InstructorServiceTest
         _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
         _mockInstructorRepository.Setup(r => r.GetSchedulesWithRelatedDataByInstructorIdAsync(instructorId))
             .ReturnsAsync(new List<Schedules> { schedule });
+        _mockInstructorRepository.Setup(r => r.GetRegularStudentsBySectionIdAsync(section.Id))
+            .ReturnsAsync(new List<Student> { activeStudent });
 
         // Act
         var result = await _service.GetSectionsWithStudentsByInstructorAsync(_testUserPrincipal);
@@ -1558,6 +1564,8 @@ public class InstructorServiceTest
         _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
         _mockInstructorRepository.Setup(r => r.GetSchedulesWithRelatedDataByInstructorIdAsync(instructorId))
             .ReturnsAsync(new List<Schedules> { schedule1, schedule2 });
+        _mockInstructorRepository.Setup(r => r.GetRegularStudentsBySectionIdAsync(section.Id))
+            .ReturnsAsync(new List<Student> { student });
 
         // Act
         var result = await _service.GetSectionsWithStudentsByInstructorAsync(_testUserPrincipal);
@@ -1599,6 +1607,73 @@ public class InstructorServiceTest
         Assert.Equal("Instructor", exception.EntityName);
         Assert.Equal("GetSectionsWithStudentsByInstructor", exception.Operation);
         Assert.Same(expectedException, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task GetSectionsWithStudentsByInstructorAsync_PrimarySectionStudentsWithoutEnrollmentRows_AreIncluded()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+
+        var instructor = new Instructor { Id = instructorId, Uuid = Guid.NewGuid(), Firstname = "John", Lastname = "Doe", UserId = userId };
+        var course = new Course { Id = 1, Uuid = Guid.NewGuid(), Name = "Computer Science" };
+        var section = new Section
+        {
+            Id = 1,
+            Uuid = Guid.NewGuid(),
+            Name = "CS-3A",
+            CourseId = 1,
+            Course = course,
+            StudentEnrollments = new List<StudentEnrollment>()
+        };
+
+        var subject = new Subject { Id = 1, Uuid = Guid.NewGuid(), Name = "Mathematics", Code = "MATH101" };
+        var classroom = new Classroom { Id = 1, Uuid = Guid.NewGuid(), Name = "Room 101" };
+
+        var regularStudent = new Student
+        {
+            Id = 1,
+            Uuid = Guid.NewGuid(),
+            Firstname = "Regular",
+            Lastname = "Student",
+            SectionId = 1,
+            IsDeleted = false
+        };
+
+        var schedule = new Schedules
+        {
+            Id = 1,
+            Uuid = Guid.NewGuid(),
+            InstructorId = instructorId,
+            SectionId = 1,
+            SubjectId = 1,
+            ClassroomId = 1,
+            DayOfWeek = "Monday",
+            TimeIn = TimeOnly.FromTimeSpan(TimeSpan.FromHours(8)),
+            TimeOut = TimeOnly.FromTimeSpan(TimeSpan.FromHours(10)),
+            Section = section,
+            Subject = subject,
+            Classroom = classroom,
+            Instructor = instructor
+        };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.GetSchedulesWithRelatedDataByInstructorIdAsync(instructorId))
+            .ReturnsAsync(new List<Schedules> { schedule });
+        _mockInstructorRepository.Setup(r => r.GetRegularStudentsBySectionIdAsync(section.Id))
+            .ReturnsAsync(new List<Student> { regularStudent });
+
+        // Act
+        var result = await _service.GetSectionsWithStudentsByInstructorAsync(_testUserPrincipal);
+
+        // Assert
+        var students = result.Sections.First().Subjects.First().Students;
+        var returnedStudent = Assert.Single(students);
+        Assert.Equal(regularStudent.Id, returnedStudent.StudentId);
+        Assert.True(returnedStudent.IsRegular);
+        Assert.Equal(EnrollmentTypeConstants.Regular, returnedStudent.EnrollmentType);
     }
 
     #endregion

--- a/attendance.testproject/Services_Testing/InstructorServiceTest.cs
+++ b/attendance.testproject/Services_Testing/InstructorServiceTest.cs
@@ -1046,4 +1046,560 @@ public class InstructorServiceTest
     }
 
     #endregion
+
+    #region GetSectionsWithStudentsByInstructorAsync Tests
+
+    [Fact]
+    public async Task GetSectionsWithStudentsByInstructorAsync_Success_ReturnsMappedDto()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        var instructorGuid = Guid.NewGuid();
+        var sectionGuid = Guid.NewGuid();
+        var courseGuid = Guid.NewGuid();
+        var subjectGuid = Guid.NewGuid();
+        var scheduleGuid = Guid.NewGuid();
+        var classroomGuid = Guid.NewGuid();
+        var student1Guid = Guid.NewGuid();
+        var student2Guid = Guid.NewGuid();
+
+        var instructor = new Instructor
+        {
+            Id = instructorId,
+            Uuid = instructorGuid,
+            Firstname = "John",
+            Lastname = "Doe",
+            UserId = userId
+        };
+
+        var course = new Course { Id = 1, Uuid = courseGuid, Name = "Computer Science" };
+        var section = new Section
+        {
+            Id = 1,
+            Uuid = sectionGuid,
+            Name = "CS-3A",
+            CourseId = 1,
+            Course = course,
+            StudentEnrollments = new List<StudentEnrollment>()
+        };
+
+        var subject = new Subject { Id = 1, Uuid = subjectGuid, Name = "Data Structures", Code = "CS301" };
+        var classroom = new Classroom { Id = 1, Uuid = classroomGuid, Name = "Room 101" };
+
+        var student1 = new Student
+        {
+            Id = 1,
+            Uuid = student1Guid,
+            Firstname = "Alice",
+            Lastname = "Smith",
+            SectionId = 1,
+            IsDeleted = false
+        };
+
+        var student2 = new Student
+        {
+            Id = 2,
+            Uuid = student2Guid,
+            Firstname = "Bob",
+            Lastname = "Johnson",
+            SectionId = 2, // Different section - irregular student
+            IsDeleted = false
+        };
+
+        var enrollment1 = new StudentEnrollment
+        {
+            StudentId = 1,
+            SectionId = 1,
+            SubjectId = 1,
+            Student = student1,
+            IsActive = true,
+            EnrollmentType = "Regular"
+        };
+
+        var enrollment2 = new StudentEnrollment
+        {
+            StudentId = 2,
+            SectionId = 1,
+            SubjectId = 1,
+            Student = student2,
+            IsActive = true,
+            EnrollmentType = "Irregular"
+        };
+
+        section.StudentEnrollments = new List<StudentEnrollment> { enrollment1, enrollment2 };
+
+        var schedule = new Schedules
+        {
+            Id = 1,
+            Uuid = scheduleGuid,
+            InstructorId = instructorId,
+            SectionId = 1,
+            SubjectId = 1,
+            ClassroomId = 1,
+            DayOfWeek = "Monday",
+            TimeIn = TimeOnly.FromTimeSpan(TimeSpan.FromHours(8)),
+            TimeOut = TimeOnly.FromTimeSpan(TimeSpan.FromHours(10)),
+            Section = section,
+            Subject = subject,
+            Classroom = classroom,
+            Instructor = instructor
+        };
+
+        var schedules = new List<Schedules> { schedule };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.GetSchedulesWithRelatedDataByInstructorIdAsync(instructorId))
+            .ReturnsAsync(schedules);
+
+        // Act
+        var result = await _service.GetSectionsWithStudentsByInstructorAsync(_testUserPrincipal);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(instructorId, result.InstructorId);
+        Assert.Equal(instructorGuid, result.InstructorUuid);
+        Assert.Equal("John", result.InstructorFirstname);
+        Assert.Equal("Doe", result.InstructorLastname);
+        Assert.Single(result.Sections);
+
+        var sectionDto = result.Sections.First();
+        Assert.Equal(1, sectionDto.SectionId);
+        Assert.Equal(sectionGuid, sectionDto.SectionUuid);
+        Assert.Equal("CS-3A", sectionDto.SectionName);
+        Assert.Equal(1, sectionDto.CourseId);
+        Assert.Equal(courseGuid, sectionDto.CourseUuid);
+        Assert.Equal("Computer Science", sectionDto.CourseName);
+        Assert.Single(sectionDto.Subjects);
+
+        var subjectDto = sectionDto.Subjects.First();
+        Assert.Equal(1, subjectDto.SubjectId);
+        Assert.Equal(subjectGuid, subjectDto.SubjectUuid);
+        Assert.Equal("Data Structures", subjectDto.SubjectName);
+        Assert.Equal("CS301", subjectDto.SubjectCode);
+        Assert.Equal(1, subjectDto.ScheduleId);
+        Assert.Equal(scheduleGuid, subjectDto.ScheduleUuid);
+        Assert.Equal("Monday", subjectDto.DayOfWeek);
+        Assert.Equal(1, subjectDto.ClassroomId);
+        Assert.Equal(classroomGuid, subjectDto.ClassroomUuid);
+        Assert.Equal("Room 101", subjectDto.ClassroomName);
+        Assert.Equal(2, subjectDto.Students.Count);
+
+        var regularStudent = subjectDto.Students.First(s => s.StudentId == 1);
+        Assert.Equal(student1Guid, regularStudent.StudentUuid);
+        Assert.Equal("Alice", regularStudent.Firstname);
+        Assert.Equal("Smith", regularStudent.Lastname);
+        Assert.True(regularStudent.IsRegular);
+        Assert.Equal("Regular", regularStudent.EnrollmentType);
+
+        var irregularStudent = subjectDto.Students.First(s => s.StudentId == 2);
+        Assert.Equal(student2Guid, irregularStudent.StudentUuid);
+        Assert.Equal("Bob", irregularStudent.Firstname);
+        Assert.Equal("Johnson", irregularStudent.Lastname);
+        Assert.False(irregularStudent.IsRegular);
+        Assert.Equal("Irregular", irregularStudent.EnrollmentType);
+
+        _mockInstructorRepository.Verify(r => r.GetSchedulesWithRelatedDataByInstructorIdAsync(instructorId), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetSectionsWithStudentsByInstructorAsync_RegularAndIrregularStudents_AggregatesCorrectly()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+
+        var instructor = new Instructor { Id = instructorId, Uuid = Guid.NewGuid(), Firstname = "John", Lastname = "Doe", UserId = userId };
+        var course = new Course { Id = 1, Uuid = Guid.NewGuid(), Name = "Computer Science" };
+        var section = new Section
+        {
+            Id = 1,
+            Uuid = Guid.NewGuid(),
+            Name = "CS-3A",
+            CourseId = 1,
+            Course = course,
+            StudentEnrollments = new List<StudentEnrollment>()
+        };
+
+        var subject = new Subject { Id = 1, Uuid = Guid.NewGuid(), Name = "Mathematics", Code = "MATH101" };
+        var classroom = new Classroom { Id = 1, Uuid = Guid.NewGuid(), Name = "Room 101" };
+
+        // Regular student (SectionId matches)
+        var regularStudent = new Student
+        {
+            Id = 1,
+            Uuid = Guid.NewGuid(),
+            Firstname = "Regular",
+            Lastname = "Student",
+            SectionId = 1,
+            IsDeleted = false
+        };
+
+        // Irregular student (SectionId different)
+        var irregularStudent = new Student
+        {
+            Id = 2,
+            Uuid = Guid.NewGuid(),
+            Firstname = "Irregular",
+            Lastname = "Student",
+            SectionId = 2,
+            IsDeleted = false
+        };
+
+        var enrollment1 = new StudentEnrollment
+        {
+            StudentId = 1,
+            SectionId = 1,
+            SubjectId = 1,
+            Student = regularStudent,
+            IsActive = true,
+            EnrollmentType = "Regular"
+        };
+
+        var enrollment2 = new StudentEnrollment
+        {
+            StudentId = 2,
+            SectionId = 1,
+            SubjectId = 1,
+            Student = irregularStudent,
+            IsActive = true,
+            EnrollmentType = "Irregular"
+        };
+
+        section.StudentEnrollments = new List<StudentEnrollment> { enrollment1, enrollment2 };
+
+        var schedule = new Schedules
+        {
+            Id = 1,
+            Uuid = Guid.NewGuid(),
+            InstructorId = instructorId,
+            SectionId = 1,
+            SubjectId = 1,
+            ClassroomId = 1,
+            DayOfWeek = "Monday",
+            TimeIn = TimeOnly.FromTimeSpan(TimeSpan.FromHours(8)),
+            TimeOut = TimeOnly.FromTimeSpan(TimeSpan.FromHours(10)),
+            Section = section,
+            Subject = subject,
+            Classroom = classroom,
+            Instructor = instructor
+        };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.GetSchedulesWithRelatedDataByInstructorIdAsync(instructorId))
+            .ReturnsAsync(new List<Schedules> { schedule });
+
+        // Act
+        var result = await _service.GetSectionsWithStudentsByInstructorAsync(_testUserPrincipal);
+
+        // Assert
+        Assert.NotNull(result);
+        var students = result.Sections.First().Subjects.First().Students;
+        Assert.Equal(2, students.Count);
+
+        var regular = students.First(s => s.StudentId == 1);
+        Assert.True(regular.IsRegular);
+        Assert.Equal("Regular", regular.EnrollmentType);
+
+        var irregular = students.First(s => s.StudentId == 2);
+        Assert.False(irregular.IsRegular);
+        Assert.Equal("Irregular", irregular.EnrollmentType);
+    }
+
+    [Fact]
+    public async Task GetSectionsWithStudentsByInstructorAsync_MissingUserId_ThrowsEntityNotFoundException()
+    {
+        // Arrange
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync((string?)null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<string>>(
+            () => _service.GetSectionsWithStudentsByInstructorAsync(_testUserPrincipal));
+        Assert.Equal("User", exception.EntityName);
+    }
+
+    [Fact]
+    public async Task GetSectionsWithStudentsByInstructorAsync_InstructorNotFound_ThrowsEntityNotFoundException()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync((Instructor?)null);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<string>>(
+            () => _service.GetSectionsWithStudentsByInstructorAsync(_testUserPrincipal));
+        Assert.Equal("Instructor", exception.EntityName);
+    }
+
+    [Fact]
+    public async Task GetSectionsWithStudentsByInstructorAsync_NoSchedules_ReturnsEmptySections()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        var instructor = new Instructor
+        {
+            Id = instructorId,
+            Uuid = Guid.NewGuid(),
+            Firstname = "John",
+            Lastname = "Doe",
+            UserId = userId
+        };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.GetSchedulesWithRelatedDataByInstructorIdAsync(instructorId))
+            .ReturnsAsync(new List<Schedules>());
+
+        // Act
+        var result = await _service.GetSectionsWithStudentsByInstructorAsync(_testUserPrincipal);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(instructorId, result.InstructorId);
+        Assert.Equal("John", result.InstructorFirstname);
+        Assert.Equal("Doe", result.InstructorLastname);
+        Assert.Empty(result.Sections);
+    }
+
+    [Fact]
+    public async Task GetSectionsWithStudentsByInstructorAsync_SoftDeletedStudents_ExcludesDeletedStudents()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+
+        var instructor = new Instructor { Id = instructorId, Uuid = Guid.NewGuid(), Firstname = "John", Lastname = "Doe", UserId = userId };
+        var course = new Course { Id = 1, Uuid = Guid.NewGuid(), Name = "Computer Science" };
+        var section = new Section
+        {
+            Id = 1,
+            Uuid = Guid.NewGuid(),
+            Name = "CS-3A",
+            CourseId = 1,
+            Course = course,
+            StudentEnrollments = new List<StudentEnrollment>()
+        };
+
+        var subject = new Subject { Id = 1, Uuid = Guid.NewGuid(), Name = "Mathematics", Code = "MATH101" };
+        var classroom = new Classroom { Id = 1, Uuid = Guid.NewGuid(), Name = "Room 101" };
+
+        // Active student
+        var activeStudent = new Student
+        {
+            Id = 1,
+            Uuid = Guid.NewGuid(),
+            Firstname = "Active",
+            Lastname = "Student",
+            SectionId = 1,
+            IsDeleted = false
+        };
+
+        // Soft-deleted student
+        var deletedStudent = new Student
+        {
+            Id = 2,
+            Uuid = Guid.NewGuid(),
+            Firstname = "Deleted",
+            Lastname = "Student",
+            SectionId = 1,
+            IsDeleted = true,
+            DeletedAt = DateTime.UtcNow.AddDays(-1)
+        };
+
+        var enrollment1 = new StudentEnrollment
+        {
+            StudentId = 1,
+            SectionId = 1,
+            SubjectId = 1,
+            Student = activeStudent,
+            IsActive = true,
+            EnrollmentType = "Regular"
+        };
+
+        var enrollment2 = new StudentEnrollment
+        {
+            StudentId = 2,
+            SectionId = 1,
+            SubjectId = 1,
+            Student = deletedStudent,
+            IsActive = true,
+            EnrollmentType = "Regular"
+        };
+
+        section.StudentEnrollments = new List<StudentEnrollment> { enrollment1, enrollment2 };
+
+        var schedule = new Schedules
+        {
+            Id = 1,
+            Uuid = Guid.NewGuid(),
+            InstructorId = instructorId,
+            SectionId = 1,
+            SubjectId = 1,
+            ClassroomId = 1,
+            DayOfWeek = "Monday",
+            TimeIn = TimeOnly.FromTimeSpan(TimeSpan.FromHours(8)),
+            TimeOut = TimeOnly.FromTimeSpan(TimeSpan.FromHours(10)),
+            Section = section,
+            Subject = subject,
+            Classroom = classroom,
+            Instructor = instructor
+        };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.GetSchedulesWithRelatedDataByInstructorIdAsync(instructorId))
+            .ReturnsAsync(new List<Schedules> { schedule });
+
+        // Act
+        var result = await _service.GetSectionsWithStudentsByInstructorAsync(_testUserPrincipal);
+
+        // Assert
+        Assert.NotNull(result);
+        var students = result.Sections.First().Subjects.First().Students;
+        Assert.Single(students);
+        Assert.Equal(1, students.First().StudentId);
+        Assert.Equal("Active", students.First().Firstname);
+    }
+
+    [Fact]
+    public async Task GetSectionsWithStudentsByInstructorAsync_MultipleSubjectsForSameSection_ReturnsAllSubjects()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+
+        var instructor = new Instructor { Id = instructorId, Uuid = Guid.NewGuid(), Firstname = "John", Lastname = "Doe", UserId = userId };
+        var course = new Course { Id = 1, Uuid = Guid.NewGuid(), Name = "Computer Science" };
+        var section = new Section
+        {
+            Id = 1,
+            Uuid = Guid.NewGuid(),
+            Name = "CS-3A",
+            CourseId = 1,
+            Course = course,
+            StudentEnrollments = new List<StudentEnrollment>()
+        };
+
+        var subject1 = new Subject { Id = 1, Uuid = Guid.NewGuid(), Name = "Mathematics", Code = "MATH101" };
+        var subject2 = new Subject { Id = 2, Uuid = Guid.NewGuid(), Name = "Physics", Code = "PHYS101" };
+        var classroom = new Classroom { Id = 1, Uuid = Guid.NewGuid(), Name = "Room 101" };
+
+        var student = new Student
+        {
+            Id = 1,
+            Uuid = Guid.NewGuid(),
+            Firstname = "Alice",
+            Lastname = "Smith",
+            SectionId = 1,
+            IsDeleted = false
+        };
+
+        var enrollment1 = new StudentEnrollment
+        {
+            StudentId = 1,
+            SectionId = 1,
+            SubjectId = 1,
+            Student = student,
+            IsActive = true,
+            EnrollmentType = "Regular"
+        };
+
+        var enrollment2 = new StudentEnrollment
+        {
+            StudentId = 1,
+            SectionId = 1,
+            SubjectId = 2,
+            Student = student,
+            IsActive = true,
+            EnrollmentType = "Regular"
+        };
+
+        section.StudentEnrollments = new List<StudentEnrollment> { enrollment1, enrollment2 };
+
+        var schedule1 = new Schedules
+        {
+            Id = 1,
+            Uuid = Guid.NewGuid(),
+            InstructorId = instructorId,
+            SectionId = 1,
+            SubjectId = 1,
+            ClassroomId = 1,
+            DayOfWeek = "Monday",
+            TimeIn = TimeOnly.FromTimeSpan(TimeSpan.FromHours(8)),
+            TimeOut = TimeOnly.FromTimeSpan(TimeSpan.FromHours(10)),
+            Section = section,
+            Subject = subject1,
+            Classroom = classroom,
+            Instructor = instructor
+        };
+
+        var schedule2 = new Schedules
+        {
+            Id = 2,
+            Uuid = Guid.NewGuid(),
+            InstructorId = instructorId,
+            SectionId = 1,
+            SubjectId = 2,
+            ClassroomId = 1,
+            DayOfWeek = "Tuesday",
+            TimeIn = TimeOnly.FromTimeSpan(TimeSpan.FromHours(10)),
+            TimeOut = TimeOnly.FromTimeSpan(TimeSpan.FromHours(12)),
+            Section = section,
+            Subject = subject2,
+            Classroom = classroom,
+            Instructor = instructor
+        };
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.GetSchedulesWithRelatedDataByInstructorIdAsync(instructorId))
+            .ReturnsAsync(new List<Schedules> { schedule1, schedule2 });
+
+        // Act
+        var result = await _service.GetSectionsWithStudentsByInstructorAsync(_testUserPrincipal);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Sections);
+        var sectionDto = result.Sections.First();
+        Assert.Equal(2, sectionDto.Subjects.Count);
+
+        var mathSubject = sectionDto.Subjects.First(s => s.SubjectCode == "MATH101");
+        Assert.Equal("Mathematics", mathSubject.SubjectName);
+        Assert.Equal("Monday", mathSubject.DayOfWeek);
+
+        var physicsSubject = sectionDto.Subjects.First(s => s.SubjectCode == "PHYS101");
+        Assert.Equal("Physics", physicsSubject.SubjectName);
+        Assert.Equal("Tuesday", physicsSubject.DayOfWeek);
+    }
+
+    [Fact]
+    public async Task GetSectionsWithStudentsByInstructorAsync_RepositoryFailure_WrapsInEntityServiceException()
+    {
+        // Arrange
+        const string userId = "test-user-id";
+        const int instructorId = 1;
+        var instructor = new Instructor { Id = instructorId, Uuid = Guid.NewGuid(), Firstname = "John", Lastname = "Doe", UserId = userId };
+        var expectedException = new InvalidOperationException("Database error");
+
+        _mockUserContextService.Setup(s => s.GetUserIdAsync(_testUserPrincipal)).ReturnsAsync(userId);
+        _mockInstructorRepository.Setup(r => r.GetInstructorByUserIdAsync(userId)).ReturnsAsync(instructor);
+        _mockInstructorRepository.Setup(r => r.GetSchedulesWithRelatedDataByInstructorIdAsync(instructorId))
+            .ThrowsAsync(expectedException);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.GetSectionsWithStudentsByInstructorAsync(_testUserPrincipal));
+
+        // Assert
+        Assert.Equal("Instructor", exception.EntityName);
+        Assert.Equal("GetSectionsWithStudentsByInstructor", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    #endregion
 }

--- a/attendance.testproject/Services_Testing/StudentEnrollmentServiceTest.cs
+++ b/attendance.testproject/Services_Testing/StudentEnrollmentServiceTest.cs
@@ -1,4 +1,5 @@
 using attendance_monitoring.Classes;
+using attendance_monitoring.Constants;
 using attendance_monitoring.Exceptions;
 using attendance_monitoring.IRepository;
 using attendance_monitoring.Services;
@@ -120,6 +121,46 @@ public class StudentEnrollmentServiceTest
         Assert.Equal(enrollmentType, result.EnrollmentType);
         Assert.Equal(academicYear, result.AcademicYear);
         Assert.Equal(semester, result.Semester);
+    }
+
+    [Theory]
+    [InlineData("Regular")]
+    [InlineData("Irregular")]
+    [InlineData("Retake")]
+    [InlineData("regular")]
+    public async Task EnrollStudentAsync_KnownEnrollmentTypes_AcceptsAndNormalizes(string enrollmentType)
+    {
+        // Arrange
+        var studentId = 1;
+        var sectionId = 2;
+        var subjectId = 3;
+        var student = new Student { Id = studentId, SectionId = 5, IsDeleted = false };
+        var section = new Section { Id = sectionId };
+        var subject = new Subject { Id = subjectId };
+
+        _mockStudentRepo.Setup(r => r.GetStudentByIdAsync(studentId)).ReturnsAsync(student);
+        _mockSectionRepo.Setup(r => r.GetSectionByIdAsync(sectionId)).ReturnsAsync(section);
+        _mockSubjectRepo.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync(subject);
+        _mockEnrollmentRepo.Setup(r => r.GetEnrollmentAsync(studentId, sectionId, subjectId))
+            .ReturnsAsync((StudentEnrollment?)null);
+        _mockEnrollmentRepo.Setup(r => r.CreateAsync(It.IsAny<StudentEnrollment>()))
+            .ReturnsAsync((StudentEnrollment e) => e);
+
+        // Act
+        var result = await _service.EnrollStudentAsync(studentId, sectionId, subjectId, enrollmentType);
+
+        // Assert
+        Assert.Equal(EnrollmentTypeConstants.Normalize(enrollmentType), result.EnrollmentType);
+    }
+
+    [Fact]
+    public async Task EnrollStudentAsync_UnknownEnrollmentType_ThrowsValidationException()
+    {
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ValidationException>(
+            () => _service.EnrollStudentAsync(1, 2, 3, "Elective"));
+
+        Assert.Equal("Enrollment type must be one of: Regular, Irregular, Retake", exception.Message);
     }
 
     [Fact]

--- a/attendance_monitoring/Constants/EnrollmentTypeConstants.cs
+++ b/attendance_monitoring/Constants/EnrollmentTypeConstants.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace attendance_monitoring.Constants;
+
+public static class EnrollmentTypeConstants
+{
+    public const string Regular = "Regular";
+    public const string Irregular = "Irregular";
+    public const string Retake = "Retake";
+
+    public static IReadOnlyList<string> All { get; } =
+    [
+        Regular,
+        Irregular,
+        Retake
+    ];
+
+    public static bool IsValid(string? enrollmentType)
+    {
+        return !string.IsNullOrWhiteSpace(enrollmentType)
+               && All.Any(candidate => string.Equals(candidate, enrollmentType, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public static string Normalize(string? enrollmentType)
+    {
+        if (string.IsNullOrWhiteSpace(enrollmentType))
+        {
+            return string.Empty;
+        }
+
+        return All.FirstOrDefault(candidate => string.Equals(candidate, enrollmentType, StringComparison.OrdinalIgnoreCase))
+               ?? enrollmentType;
+    }
+}

--- a/attendance_monitoring/Controllers/InstructorController.cs
+++ b/attendance_monitoring/Controllers/InstructorController.cs
@@ -189,6 +189,98 @@ public class InstructorController(IInstructorService instructorService, ILogger<
         }
     }
 
+    // GET: api/instructors/me/sections
+    [HttpGet("me/sections")]
+    [Authorize(Policy = "PrivilegedPolicy")]
+    public async Task<ActionResult<List<InstructorSectionOverviewDto>>> GetMySectionsOverview()
+    {
+        try
+        {
+            logger.LogInformation("Getting sections overview for authenticated instructor");
+            var sections = await instructorService.GetInstructorSectionsOverviewAsync(User);
+            logger.LogInformation("Successfully retrieved {Count} section overviews for authenticated instructor", sections.Count);
+            return Ok(sections);
+        }
+        catch (EntityNotFoundException<string> ex)
+        {
+            logger.LogWarning(ex, "Instructor not found for authenticated user");
+            return NotFound("No instructor record found for the current user");
+        }
+        catch (EntityServiceException ex)
+        {
+            logger.LogError(ex, "Service error occurred while retrieving sections overview");
+            return StatusCode(500, "An error occurred while retrieving sections overview");
+        }
+    }
+
+    // GET: api/instructors/me/sections/{sectionId:int}
+    [HttpGet("me/sections/{sectionId:int}")]
+    [Authorize(Policy = "PrivilegedPolicy")]
+    public async Task<ActionResult<InstructorSectionDetailDto>> GetMySectionDetail(int sectionId)
+    {
+        try
+        {
+            logger.LogInformation("Getting section detail for section ID: {SectionId}", sectionId);
+            var sectionDetail = await instructorService.GetInstructorSectionDetailAsync(User, sectionId);
+            logger.LogInformation("Successfully retrieved section detail for section ID: {SectionId}", sectionId);
+            return Ok(sectionDetail);
+        }
+        catch (EntityNotFoundException<string> ex)
+        {
+            logger.LogWarning(ex, "Instructor not found for authenticated user");
+            return NotFound("No instructor record found for the current user");
+        }
+        catch (EntityNotFoundException<int> ex)
+        {
+            logger.LogWarning(ex, "Section with ID {SectionId} not found", sectionId);
+            return NotFound($"Section with ID {sectionId} not found");
+        }
+        catch (EntityUnauthorizedException ex)
+        {
+            logger.LogWarning(ex, "User not authorized to view section with ID {SectionId}", sectionId);
+            return Unauthorized(ex.Message);
+        }
+        catch (EntityServiceException ex)
+        {
+            logger.LogError(ex, "Service error occurred while retrieving section detail for section ID: {SectionId}", sectionId);
+            return StatusCode(500, "An error occurred while retrieving section detail");
+        }
+    }
+
+    // GET: api/instructors/me/students/{studentId:int}
+    [HttpGet("me/students/{studentId:int}")]
+    [Authorize(Policy = "PrivilegedPolicy")]
+    public async Task<ActionResult<InstructorStudentDetailDto>> GetMyStudentDetail(int studentId)
+    {
+        try
+        {
+            logger.LogInformation("Getting student detail for student ID: {StudentId}", studentId);
+            var studentDetail = await instructorService.GetInstructorStudentDetailAsync(User, studentId);
+            logger.LogInformation("Successfully retrieved student detail for student ID: {StudentId}", studentId);
+            return Ok(studentDetail);
+        }
+        catch (EntityNotFoundException<string> ex)
+        {
+            logger.LogWarning(ex, "Instructor not found for authenticated user");
+            return NotFound("No instructor record found for the current user");
+        }
+        catch (EntityNotFoundException<int> ex)
+        {
+            logger.LogWarning(ex, "Student with ID {StudentId} not found", studentId);
+            return NotFound($"Student with ID {studentId} not found");
+        }
+        catch (EntityUnauthorizedException ex)
+        {
+            logger.LogWarning(ex, "User not authorized to view student with ID {StudentId}", studentId);
+            return Unauthorized(ex.Message);
+        }
+        catch (EntityServiceException ex)
+        {
+            logger.LogError(ex, "Service error occurred while retrieving student detail for student ID: {StudentId}", studentId);
+            return StatusCode(500, "An error occurred while retrieving student detail");
+        }
+    }
+
     #endregion
 
     #region Update Operations

--- a/attendance_monitoring/Controllers/InstructorController.cs
+++ b/attendance_monitoring/Controllers/InstructorController.cs
@@ -238,7 +238,7 @@ public class InstructorController(IInstructorService instructorService, ILogger<
         catch (EntityUnauthorizedException ex)
         {
             logger.LogWarning(ex, "User not authorized to view section with ID {SectionId}", sectionId);
-            return Unauthorized(ex.Message);
+            return StatusCode(StatusCodes.Status403Forbidden, ex.Message);
         }
         catch (EntityServiceException ex)
         {
@@ -272,7 +272,7 @@ public class InstructorController(IInstructorService instructorService, ILogger<
         catch (EntityUnauthorizedException ex)
         {
             logger.LogWarning(ex, "User not authorized to view student with ID {StudentId}", studentId);
-            return Unauthorized(ex.Message);
+            return StatusCode(StatusCodes.Status403Forbidden, ex.Message);
         }
         catch (EntityServiceException ex)
         {
@@ -337,7 +337,7 @@ public class InstructorController(IInstructorService instructorService, ILogger<
         catch (EntityUnauthorizedException ex)
         {
             logger.LogWarning(ex, "User not authorized to update instructor with ID {Id}", id);
-            return Unauthorized(ex.Message);
+            return StatusCode(StatusCodes.Status403Forbidden, ex.Message);
         }
         catch (EntityServiceException ex)
         {
@@ -378,7 +378,7 @@ public class InstructorController(IInstructorService instructorService, ILogger<
         catch (EntityUnauthorizedException ex)
         {
             logger.LogWarning(ex, "User not authorized to delete instructor with ID {Id}", id);
-            return Unauthorized(new SoftDeleteResponse
+            return StatusCode(StatusCodes.Status403Forbidden, new SoftDeleteResponse
             {
                 Success = false,
                 Message = ex.Message

--- a/attendance_monitoring/Controllers/InstructorController.cs
+++ b/attendance_monitoring/Controllers/InstructorController.cs
@@ -165,6 +165,30 @@ public class InstructorController(IInstructorService instructorService, ILogger<
         }
     }
 
+    // GET: api/instructors/me/sections-with-students
+    [HttpGet("me/sections-with-students")]
+    [Authorize(Policy = "PrivilegedPolicy")]
+    public async Task<ActionResult<InstructorSectionsWithStudentsResponseDto>> GetMySectionsWithStudents()
+    {
+        try
+        {
+            logger.LogInformation("Getting sections with students for authenticated instructor");
+            var response = await instructorService.GetSectionsWithStudentsByInstructorAsync(User);
+            logger.LogInformation("Successfully retrieved sections with students for instructor ID: {InstructorId}", response.InstructorId);
+            return Ok(response);
+        }
+        catch (EntityNotFoundException<string> ex)
+        {
+            logger.LogWarning(ex, "Instructor not found for authenticated user");
+            return NotFound("No instructor record found for the current user");
+        }
+        catch (EntityServiceException ex)
+        {
+            logger.LogError(ex, "Service error occurred while retrieving sections with students");
+            return StatusCode(500, "An error occurred while retrieving sections");
+        }
+    }
+
     #endregion
 
     #region Update Operations

--- a/attendance_monitoring/Controllers/StudentEnrollmentController.cs
+++ b/attendance_monitoring/Controllers/StudentEnrollmentController.cs
@@ -83,6 +83,11 @@ public class StudentEnrollmentController : ControllerBase
             _logger.LogWarning(ex, "Duplicate enrollment attempt for student {StudentId}", request.StudentId);
             return Conflict(new { message = ex.Message });
         }
+        catch (ValidationException ex)
+        {
+            _logger.LogWarning(ex, "Invalid enrollment request for student {StudentId}", request.StudentId);
+            return BadRequest(new { message = ex.Message });
+        }
         // No generic catch - let global exception handler handle unexpected errors
     }
 

--- a/attendance_monitoring/IRepository/IInstructorRepository.cs
+++ b/attendance_monitoring/IRepository/IInstructorRepository.cs
@@ -97,4 +97,11 @@ public interface IInstructorRepository : ISaveableRepository
     /// <returns>A collection of schedules with eagerly loaded related entities.</returns>
     Task<IEnumerable<Schedules>> GetSchedulesWithRelatedDataByInstructorIdAsync(int instructorId);
 
+    /// <summary>
+    /// Retrieves regular students whose primary section matches the supplied section.
+    /// </summary>
+    /// <param name="sectionId">The section ID.</param>
+    /// <returns>A collection of regular students in the section.</returns>
+    Task<IEnumerable<Student>> GetRegularStudentsBySectionIdAsync(int sectionId);
+
 }

--- a/attendance_monitoring/IRepository/IInstructorRepository.cs
+++ b/attendance_monitoring/IRepository/IInstructorRepository.cs
@@ -90,4 +90,11 @@ public interface IInstructorRepository : ISaveableRepository
     /// <returns>True if the instructor was restored; otherwise, false.</returns>
     Task<bool> RestoreInstructorAsync(int id);
 
+    /// <summary>
+    /// Retrieves all schedules with related data (Section, Course, Subject, Classroom, Students, StudentEnrollments) for a specific instructor.
+    /// </summary>
+    /// <param name="instructorId">The instructor ID.</param>
+    /// <returns>A collection of schedules with eagerly loaded related entities.</returns>
+    Task<IEnumerable<Schedules>> GetSchedulesWithRelatedDataByInstructorIdAsync(int instructorId);
+
 }

--- a/attendance_monitoring/IRepository/IInstructorRepository.cs
+++ b/attendance_monitoring/IRepository/IInstructorRepository.cs
@@ -104,4 +104,49 @@ public interface IInstructorRepository : ISaveableRepository
     /// <returns>A collection of regular students in the section.</returns>
     Task<IEnumerable<Student>> GetRegularStudentsBySectionIdAsync(int sectionId);
 
+    /// <summary>
+    /// Retrieves all sections handled by the instructor, including course data.
+    /// </summary>
+    /// <param name="instructorId">The instructor ID.</param>
+    /// <returns>A collection of sections handled by the instructor.</returns>
+    Task<IEnumerable<Section>> GetHandledSectionsByInstructorIdAsync(int instructorId);
+
+    /// <summary>
+    /// Retrieves handled classes for a specific section and instructor with related data.
+    /// </summary>
+    /// <param name="sectionId">The section ID.</param>
+    /// <param name="instructorId">The instructor ID.</param>
+    /// <returns>A collection of schedules for the supplied section and instructor.</returns>
+    Task<IEnumerable<Schedules>> GetHandledClassesBySectionAndInstructorAsync(int sectionId, int instructorId);
+
+    /// <summary>
+    /// Retrieves all non-deleted students whose home section matches the supplied section.
+    /// </summary>
+    /// <param name="sectionId">The section ID.</param>
+    /// <returns>A collection of home section students.</returns>
+    Task<IEnumerable<Student>> GetHomeSectionStudentsAsync(int sectionId);
+
+    /// <summary>
+    /// Determines whether the instructor handles the supplied section.
+    /// </summary>
+    /// <param name="instructorId">The instructor ID.</param>
+    /// <param name="sectionId">The section ID.</param>
+    /// <returns><c>true</c> if the instructor handles the section; otherwise, <c>false</c>.</returns>
+    Task<bool> IsInstructorHandlingSectionAsync(int instructorId, int sectionId);
+
+    /// <summary>
+    /// Retrieves a student with related section, course, and enrollment data.
+    /// </summary>
+    /// <param name="studentId">The student ID.</param>
+    /// <returns>The student with related details if found; otherwise, null.</returns>
+    Task<Student?> GetStudentWithDetailsAsync(int studentId);
+
+    /// <summary>
+    /// Retrieves attendance records for a student in sessions taught by the supplied instructor.
+    /// </summary>
+    /// <param name="studentId">The student ID.</param>
+    /// <param name="instructorId">The instructor ID.</param>
+    /// <returns>A collection of attendance records for instructor-taught subjects.</returns>
+    Task<IEnumerable<AttendanceRecord>> GetStudentAttendanceForInstructorSubjectsAsync(int studentId, int instructorId);
+
 }

--- a/attendance_monitoring/IServices/IInstructorService.cs
+++ b/attendance_monitoring/IServices/IInstructorService.cs
@@ -12,6 +12,7 @@ public interface IInstructorService
     Task<IEnumerable<SubjectResponseDto>> GetSubjectsByInstructorIdAsync(int instructorId);
     Task<IEnumerable<ScheduleResponseDto>> GetSchedulesByInstructorAsync(ClaimsPrincipal user);
     Task<InstructorProfileResponseDto?> GetInstructorProfileAsync(ClaimsPrincipal user);
+    Task<InstructorSectionsWithStudentsResponseDto> GetSectionsWithStudentsByInstructorAsync(ClaimsPrincipal user);
     Task<Instructor> CreateInstructorAsync(CreateInstructor createInstructor, ClaimsPrincipal user);
     Task<Instructor> UpdateInstructorAsync(int id, UpdateInstructor updateInstructor, ClaimsPrincipal user);
     Task SoftDeleteInstructorAsync(int id, ClaimsPrincipal user);

--- a/attendance_monitoring/IServices/IInstructorService.cs
+++ b/attendance_monitoring/IServices/IInstructorService.cs
@@ -13,6 +13,9 @@ public interface IInstructorService
     Task<IEnumerable<ScheduleResponseDto>> GetSchedulesByInstructorAsync(ClaimsPrincipal user);
     Task<InstructorProfileResponseDto?> GetInstructorProfileAsync(ClaimsPrincipal user);
     Task<InstructorSectionsWithStudentsResponseDto> GetSectionsWithStudentsByInstructorAsync(ClaimsPrincipal user);
+    Task<List<InstructorSectionOverviewDto>> GetInstructorSectionsOverviewAsync(ClaimsPrincipal user);
+    Task<InstructorSectionDetailDto> GetInstructorSectionDetailAsync(ClaimsPrincipal user, int sectionId);
+    Task<InstructorStudentDetailDto> GetInstructorStudentDetailAsync(ClaimsPrincipal user, int studentId);
     Task<Instructor> CreateInstructorAsync(CreateInstructor createInstructor, ClaimsPrincipal user);
     Task<Instructor> UpdateInstructorAsync(int id, UpdateInstructor updateInstructor, ClaimsPrincipal user);
     Task SoftDeleteInstructorAsync(int id, ClaimsPrincipal user);

--- a/attendance_monitoring/Models/DTO/Request/CreateStudentEnrollment.cs
+++ b/attendance_monitoring/Models/DTO/Request/CreateStudentEnrollment.cs
@@ -13,6 +13,7 @@ public class CreateStudentEnrollment
     [Required(ErrorMessage = "Subject ID is required")]
     public int SubjectId { get; set; }
 
+    [RegularExpression("(?i)^(Regular|Irregular|Retake)$", ErrorMessage = "Enrollment type must be one of: Regular, Irregular, Retake")]
     [StringLength(20, ErrorMessage = "Enrollment type must not exceed 20 characters")]
     public string EnrollmentType { get; set; } = "Regular";
 

--- a/attendance_monitoring/Models/DTO/Response/InstructorHandledClassDto.cs
+++ b/attendance_monitoring/Models/DTO/Response/InstructorHandledClassDto.cs
@@ -1,0 +1,113 @@
+namespace attendance_monitoring.Models.DTO.Response;
+
+/// <summary>
+/// Represents a student enrolled in a handled class for instructor drilldown views.
+/// </summary>
+public class InstructorHandledClassStudentDto
+{
+    /// <summary>
+    /// Gets or sets the student's unique identifier.
+    /// </summary>
+    public int StudentId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the student's UUID.
+    /// </summary>
+    public Guid StudentUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the student's first name.
+    /// </summary>
+    public string Firstname { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the student's last name.
+    /// </summary>
+    public string Lastname { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the student is regular.
+    /// </summary>
+    public bool IsRegular { get; set; }
+
+    /// <summary>
+    /// Gets or sets the student's enrollment type.
+    /// </summary>
+    public string EnrollmentType { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Represents an instructor-handled class with schedule, room, and student roster details.
+/// </summary>
+public class InstructorHandledClassDto
+{
+    /// <summary>
+    /// Gets or sets the subject's unique identifier.
+    /// </summary>
+    public int SubjectId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the subject's UUID.
+    /// </summary>
+    public Guid SubjectUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the subject name.
+    /// </summary>
+    public string SubjectName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the subject code.
+    /// </summary>
+    public string SubjectCode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the schedule's unique identifier.
+    /// </summary>
+    public int ScheduleId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the schedule's UUID.
+    /// </summary>
+    public Guid ScheduleUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the scheduled day of week.
+    /// </summary>
+    public string DayOfWeek { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the scheduled start time.
+    /// </summary>
+    public TimeOnly TimeIn { get; set; }
+
+    /// <summary>
+    /// Gets or sets the scheduled end time.
+    /// </summary>
+    public TimeOnly TimeOut { get; set; }
+
+    /// <summary>
+    /// Gets or sets the classroom's unique identifier.
+    /// </summary>
+    public int ClassroomId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the classroom's UUID.
+    /// </summary>
+    public Guid ClassroomUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the classroom name.
+    /// </summary>
+    public string ClassroomName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the number of students in the handled class.
+    /// </summary>
+    public int StudentCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the students associated with the handled class.
+    /// </summary>
+    public List<InstructorHandledClassStudentDto> Students { get; set; } = new();
+}

--- a/attendance_monitoring/Models/DTO/Response/InstructorHomeSectionStudentDto.cs
+++ b/attendance_monitoring/Models/DTO/Response/InstructorHomeSectionStudentDto.cs
@@ -1,0 +1,37 @@
+namespace attendance_monitoring.Models.DTO.Response;
+
+/// <summary>
+/// Represents a student belonging to an instructor section's home roster.
+/// </summary>
+public class InstructorHomeSectionStudentDto
+{
+    /// <summary>
+    /// Gets or sets the student's unique identifier.
+    /// </summary>
+    public int StudentId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the student's UUID.
+    /// </summary>
+    public Guid StudentUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the student's first name.
+    /// </summary>
+    public string Firstname { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the student's last name.
+    /// </summary>
+    public string Lastname { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the student is regular.
+    /// </summary>
+    public bool IsRegular { get; set; }
+
+    /// <summary>
+    /// Gets or sets the student's enrollment type.
+    /// </summary>
+    public string EnrollmentType { get; set; } = string.Empty;
+}

--- a/attendance_monitoring/Models/DTO/Response/InstructorSectionDetailDto.cs
+++ b/attendance_monitoring/Models/DTO/Response/InstructorSectionDetailDto.cs
@@ -1,0 +1,57 @@
+namespace attendance_monitoring.Models.DTO.Response;
+
+/// <summary>
+/// Represents section drilldown details for an instructor, including handled classes and home section students.
+/// </summary>
+public class InstructorSectionDetailDto
+{
+    /// <summary>
+    /// Gets or sets the section's unique identifier.
+    /// </summary>
+    public int SectionId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the section's UUID.
+    /// </summary>
+    public Guid SectionUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the section name.
+    /// </summary>
+    public string SectionName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the course's unique identifier.
+    /// </summary>
+    public int CourseId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the course's UUID.
+    /// </summary>
+    public Guid CourseUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the course name.
+    /// </summary>
+    public string CourseName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the number of handled classes for the section.
+    /// </summary>
+    public int HandledClassCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of students in the section's home roster.
+    /// </summary>
+    public int HomeSectionStudentCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the handled classes for the section.
+    /// </summary>
+    public List<InstructorHandledClassDto> HandledClasses { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the students in the section's home roster.
+    /// </summary>
+    public List<InstructorHomeSectionStudentDto> HomeSectionStudents { get; set; } = new();
+}

--- a/attendance_monitoring/Models/DTO/Response/InstructorSectionOverviewDto.cs
+++ b/attendance_monitoring/Models/DTO/Response/InstructorSectionOverviewDto.cs
@@ -1,0 +1,47 @@
+namespace attendance_monitoring.Models.DTO.Response;
+
+/// <summary>
+/// Represents a high-level overview of an instructor-handled section.
+/// </summary>
+public class InstructorSectionOverviewDto
+{
+    /// <summary>
+    /// Gets or sets the section's unique identifier.
+    /// </summary>
+    public int SectionId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the section's UUID.
+    /// </summary>
+    public Guid SectionUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the section name.
+    /// </summary>
+    public string SectionName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the course's unique identifier.
+    /// </summary>
+    public int CourseId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the course's UUID.
+    /// </summary>
+    public Guid CourseUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the course name.
+    /// </summary>
+    public string CourseName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the number of classes handled by the instructor for this section.
+    /// </summary>
+    public int HandledClassCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of unique students associated with the instructor's handled classes for this section.
+    /// </summary>
+    public int UniqueStudentCount { get; set; }
+}

--- a/attendance_monitoring/Models/DTO/Response/InstructorSectionsWithStudentsResponseDto.cs
+++ b/attendance_monitoring/Models/DTO/Response/InstructorSectionsWithStudentsResponseDto.cs
@@ -1,0 +1,32 @@
+namespace attendance_monitoring.Models.DTO.Response;
+
+/// <summary>
+/// Response DTO containing instructor information with their assigned sections and enrolled students.
+/// </summary>
+public class InstructorSectionsWithStudentsResponseDto
+{
+    /// <summary>
+    /// Gets or sets the instructor's unique identifier.
+    /// </summary>
+    public int InstructorId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the instructor's UUID.
+    /// </summary>
+    public Guid InstructorUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the instructor's first name.
+    /// </summary>
+    public string InstructorFirstname { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the instructor's last name.
+    /// </summary>
+    public string InstructorLastname { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the list of sections assigned to the instructor.
+    /// </summary>
+    public List<SectionWithStudentsDto> Sections { get; set; } = new();
+}

--- a/attendance_monitoring/Models/DTO/Response/InstructorStudentDetailDto.cs
+++ b/attendance_monitoring/Models/DTO/Response/InstructorStudentDetailDto.cs
@@ -1,0 +1,134 @@
+namespace attendance_monitoring.Models.DTO.Response;
+
+/// <summary>
+/// Represents a student's enrollment entry visible to an instructor.
+/// </summary>
+public class InstructorStudentEnrollmentDto
+{
+    /// <summary>
+    /// Gets or sets the subject's unique identifier.
+    /// </summary>
+    public int SubjectId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the subject name.
+    /// </summary>
+    public string SubjectName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the subject code.
+    /// </summary>
+    public string SubjectCode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the section's unique identifier.
+    /// </summary>
+    public int SectionId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the section name.
+    /// </summary>
+    public string SectionName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the enrollment type.
+    /// </summary>
+    public string EnrollmentType { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Represents aggregate attendance counts for a student.
+/// </summary>
+public class InstructorStudentAttendanceSummaryDto
+{
+    /// <summary>
+    /// Gets or sets the total number of sessions.
+    /// </summary>
+    public int TotalSessions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of present records.
+    /// </summary>
+    public int PresentCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of absent records.
+    /// </summary>
+    public int AbsentCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of late records.
+    /// </summary>
+    public int LateCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the attendance rate percentage.
+    /// </summary>
+    public double AttendanceRate { get; set; }
+}
+
+/// <summary>
+/// Represents detailed student information for instructor-facing drilldown views.
+/// </summary>
+public class InstructorStudentDetailDto
+{
+    /// <summary>
+    /// Gets or sets the student's unique identifier.
+    /// </summary>
+    public int StudentId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the student's UUID.
+    /// </summary>
+    public Guid StudentUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the student's first name.
+    /// </summary>
+    public string Firstname { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the student's last name.
+    /// </summary>
+    public string Lastname { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the home section identifier, if available.
+    /// </summary>
+    public int? SectionId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the home section name, if available.
+    /// </summary>
+    public string? SectionName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the course identifier, if available.
+    /// </summary>
+    public int? CourseId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the course name, if available.
+    /// </summary>
+    public string? CourseName { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the student is regular.
+    /// </summary>
+    public bool IsRegular { get; set; }
+
+    /// <summary>
+    /// Gets or sets the student's primary enrollment type.
+    /// </summary>
+    public string EnrollmentType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the student's enrollments relevant to the instructor view.
+    /// </summary>
+    public List<InstructorStudentEnrollmentDto> Enrollments { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the student's aggregate attendance summary.
+    /// </summary>
+    public InstructorStudentAttendanceSummaryDto AttendanceSummary { get; set; } = new();
+}

--- a/attendance_monitoring/Models/DTO/Response/SectionWithStudentsDto.cs
+++ b/attendance_monitoring/Models/DTO/Response/SectionWithStudentsDto.cs
@@ -1,0 +1,42 @@
+namespace attendance_monitoring.Models.DTO.Response;
+
+/// <summary>
+/// Response DTO containing section information with associated subjects and students.
+/// </summary>
+public class SectionWithStudentsDto
+{
+    /// <summary>
+    /// Gets or sets the section's unique identifier.
+    /// </summary>
+    public int SectionId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the section's UUID.
+    /// </summary>
+    public Guid SectionUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the section name (e.g., "BSCS 3A").
+    /// </summary>
+    public string SectionName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the course's unique identifier.
+    /// </summary>
+    public int CourseId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the course's UUID.
+    /// </summary>
+    public Guid CourseUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the course name (e.g., "Bachelor of Science in Computer Science").
+    /// </summary>
+    public string CourseName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the list of subjects taught in this section with their schedules and enrolled students.
+    /// </summary>
+    public List<SubjectScheduleDto> Subjects { get; set; } = new();
+}

--- a/attendance_monitoring/Models/DTO/Response/StudentDto.cs
+++ b/attendance_monitoring/Models/DTO/Response/StudentDto.cs
@@ -1,0 +1,37 @@
+namespace attendance_monitoring.Models.DTO.Response;
+
+/// <summary>
+/// Response DTO containing student information with enrollment status.
+/// </summary>
+public class StudentDto
+{
+    /// <summary>
+    /// Gets or sets the student's unique identifier.
+    /// </summary>
+    public int StudentId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the student's UUID.
+    /// </summary>
+    public Guid StudentUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the student's first name.
+    /// </summary>
+    public string Firstname { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the student's last name.
+    /// </summary>
+    public string Lastname { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether the student is a regular student (true) or irregular student (false).
+    /// </summary>
+    public bool IsRegular { get; set; }
+
+    /// <summary>
+    /// Gets or sets the enrollment type (e.g., "Regular", "Irregular", "Retake").
+    /// </summary>
+    public string EnrollmentType { get; set; } = "Regular";
+}

--- a/attendance_monitoring/Models/DTO/Response/SubjectScheduleDto.cs
+++ b/attendance_monitoring/Models/DTO/Response/SubjectScheduleDto.cs
@@ -1,0 +1,72 @@
+namespace attendance_monitoring.Models.DTO.Response;
+
+/// <summary>
+/// Response DTO containing subject and schedule information with enrolled students.
+/// </summary>
+public class SubjectScheduleDto
+{
+    /// <summary>
+    /// Gets or sets the subject's unique identifier.
+    /// </summary>
+    public int SubjectId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the subject's UUID.
+    /// </summary>
+    public Guid SubjectUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the subject name (e.g., "Data Structures").
+    /// </summary>
+    public string SubjectName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the subject code (e.g., "CS301").
+    /// </summary>
+    public string SubjectCode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the schedule's unique identifier.
+    /// </summary>
+    public int ScheduleId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the schedule's UUID.
+    /// </summary>
+    public Guid ScheduleUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the day of the week for this schedule (e.g., "Monday").
+    /// </summary>
+    public string DayOfWeek { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the scheduled start time.
+    /// </summary>
+    public TimeOnly TimeIn { get; set; }
+
+    /// <summary>
+    /// Gets or sets the scheduled end time.
+    /// </summary>
+    public TimeOnly TimeOut { get; set; }
+
+    /// <summary>
+    /// Gets or sets the classroom's unique identifier.
+    /// </summary>
+    public int ClassroomId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the classroom's UUID.
+    /// </summary>
+    public Guid ClassroomUuid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the classroom name where the class is held.
+    /// </summary>
+    public string ClassroomName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the list of students enrolled in this subject-section combination.
+    /// </summary>
+    public List<StudentDto> Students { get; set; } = new();
+}

--- a/attendance_monitoring/Repositories/InstructorRepository.cs
+++ b/attendance_monitoring/Repositories/InstructorRepository.cs
@@ -202,6 +202,7 @@ public class InstructorRepository(ApplicationDbContext context) : IInstructorRep
     {
         return await context.Schedules
             .AsNoTracking()
+            .AsSplitQuery()
             .Where(s => s.InstructorId == instructorId)
             .Include(s => s.Section)
                 .ThenInclude(sec => sec.Course)

--- a/attendance_monitoring/Repositories/InstructorRepository.cs
+++ b/attendance_monitoring/Repositories/InstructorRepository.cs
@@ -231,6 +231,117 @@ public class InstructorRepository(ApplicationDbContext context) : IInstructorRep
     }
     #endregion
 
+    #region GetHandledSectionsByInstructorIdAsync
+    /// <summary>
+    /// Retrieves all sections handled by the instructor, including course data.
+    /// Performance: Single query with course eager loading.
+    /// </summary>
+    public async Task<IEnumerable<Section>> GetHandledSectionsByInstructorIdAsync(int instructorId)
+    {
+        return await context.Sections
+            .AsNoTracking()
+            .Include(section => section.Course)
+            .Where(section => context.Schedules.Any(schedule => schedule.InstructorId == instructorId && schedule.SectionId == section.Id))
+            .OrderBy(section => section.Name)
+            .ToListAsync()
+            .ConfigureAwait(false);
+    }
+    #endregion
+
+    #region GetHandledClassesBySectionAndInstructorAsync
+    /// <summary>
+    /// Retrieves handled classes for a specific section and instructor with related data.
+    /// Uses eager loading to prevent N+1 queries for subject, classroom, section, and enrolled students.
+    /// </summary>
+    public async Task<IEnumerable<Schedules>> GetHandledClassesBySectionAndInstructorAsync(int sectionId, int instructorId)
+    {
+        return await context.Schedules
+            .AsNoTracking()
+            .AsSplitQuery()
+            .Where(schedule => schedule.SectionId == sectionId && schedule.InstructorId == instructorId)
+            .Include(schedule => schedule.Subject)
+            .Include(schedule => schedule.Classroom)
+            .Include(schedule => schedule.Section)
+                .ThenInclude(section => section.StudentEnrollments.Where(studentEnrollment => studentEnrollment.IsActive))
+                    .ThenInclude(studentEnrollment => studentEnrollment.Student)
+            .OrderBy(schedule => schedule.DayOfWeek)
+            .ThenBy(schedule => schedule.TimeIn)
+            .ToListAsync()
+            .ConfigureAwait(false);
+    }
+    #endregion
+
+    #region GetHomeSectionStudentsAsync
+    /// <summary>
+    /// Retrieves all non-deleted students whose home section matches the supplied section.
+    /// </summary>
+    public async Task<IEnumerable<Student>> GetHomeSectionStudentsAsync(int sectionId)
+    {
+        return await context.Students
+            .AsNoTracking()
+            .Where(student => student.SectionId == sectionId && !student.IsDeleted)
+            .OrderBy(student => student.Lastname)
+            .ThenBy(student => student.Firstname)
+            .ToListAsync()
+            .ConfigureAwait(false);
+    }
+    #endregion
+
+    #region IsInstructorHandlingSectionAsync
+    /// <summary>
+    /// Determines whether the instructor handles the supplied section.
+    /// Performance: Uses an existence check without loading entities.
+    /// </summary>
+    public async Task<bool> IsInstructorHandlingSectionAsync(int instructorId, int sectionId)
+    {
+        return await context.Schedules
+            .AsNoTracking()
+            .AnyAsync(schedule => schedule.InstructorId == instructorId && schedule.SectionId == sectionId)
+            .ConfigureAwait(false);
+    }
+    #endregion
+
+    #region GetStudentWithDetailsAsync
+    /// <summary>
+    /// Retrieves a student with related section, course, and active enrollment data.
+    /// Uses split query execution to avoid cartesian explosion when loading multiple navigations.
+    /// </summary>
+    public async Task<Student?> GetStudentWithDetailsAsync(int studentId)
+    {
+        return await context.Students
+            .AsNoTracking()
+            .AsSplitQuery()
+            .Include(student => student.Section)
+                .ThenInclude(section => section.Course)
+            .Include(student => student.AdditionalEnrollments.Where(studentEnrollment => studentEnrollment.IsActive))
+                .ThenInclude(studentEnrollment => studentEnrollment.Section)
+            .Include(student => student.AdditionalEnrollments.Where(studentEnrollment => studentEnrollment.IsActive))
+                .ThenInclude(studentEnrollment => studentEnrollment.Subject)
+            .FirstOrDefaultAsync(student => student.Id == studentId && !student.IsDeleted)
+            .ConfigureAwait(false);
+    }
+    #endregion
+
+    #region GetStudentAttendanceForInstructorSubjectsAsync
+    /// <summary>
+    /// Retrieves attendance records for a student in sessions taught by the supplied instructor.
+    /// Uses eager loading for session and schedule data commonly needed by higher layers.
+    /// </summary>
+    public async Task<IEnumerable<AttendanceRecord>> GetStudentAttendanceForInstructorSubjectsAsync(int studentId, int instructorId)
+    {
+        return await context.AttendanceRecords
+            .AsNoTracking()
+            .AsSplitQuery()
+            .Where(attendanceRecord => attendanceRecord.StudentId == studentId && attendanceRecord.Session.Schedule.InstructorId == instructorId)
+            .Include(attendanceRecord => attendanceRecord.Session)
+                .ThenInclude(session => session.Schedule)
+                    .ThenInclude(schedule => schedule.Subject)
+            .OrderByDescending(attendanceRecord => attendanceRecord.CheckInTime)
+            .ToListAsync()
+            .ConfigureAwait(false);
+    }
+    #endregion
+
     #endregion
 
     #region Utility Operations

--- a/attendance_monitoring/Repositories/InstructorRepository.cs
+++ b/attendance_monitoring/Repositories/InstructorRepository.cs
@@ -214,6 +214,23 @@ public class InstructorRepository(ApplicationDbContext context) : IInstructorRep
     }
     #endregion
 
+    #region GetRegularStudentsBySectionIdAsync
+    /// <summary>
+    /// Retrieves regular students whose primary section matches the supplied section.
+    /// Soft-deleted students are excluded.
+    /// </summary>
+    public async Task<IEnumerable<Student>> GetRegularStudentsBySectionIdAsync(int sectionId)
+    {
+        return await context.Students
+            .AsNoTracking()
+            .Where(student => student.SectionId == sectionId && !student.IsDeleted)
+            .OrderBy(student => student.Lastname)
+            .ThenBy(student => student.Firstname)
+            .ToListAsync()
+            .ConfigureAwait(false);
+    }
+    #endregion
+
     #endregion
 
     #region Utility Operations

--- a/attendance_monitoring/Repositories/InstructorRepository.cs
+++ b/attendance_monitoring/Repositories/InstructorRepository.cs
@@ -280,13 +280,7 @@ public class InstructorRepository(ApplicationDbContext context) : IInstructorRep
     /// </summary>
     public async Task<IEnumerable<Student>> GetHomeSectionStudentsAsync(int sectionId)
     {
-        return await context.Students
-            .AsNoTracking()
-            .Where(student => student.SectionId == sectionId && !student.IsDeleted)
-            .OrderBy(student => student.Lastname)
-            .ThenBy(student => student.Firstname)
-            .ToListAsync()
-            .ConfigureAwait(false);
+        return await GetRegularStudentsBySectionIdAsync(sectionId).ConfigureAwait(false);
     }
     #endregion
 

--- a/attendance_monitoring/Repositories/InstructorRepository.cs
+++ b/attendance_monitoring/Repositories/InstructorRepository.cs
@@ -187,6 +187,35 @@ public class InstructorRepository(ApplicationDbContext context) : IInstructorRep
 
     #endregion
 
+    #region Specialized Query Operations
+
+    #region GetSchedulesWithRelatedDataByInstructorIdAsync
+    /// <summary>
+    /// Retrieves all schedules with related data for a specific instructor.
+    /// Uses eager loading to minimize database round trips (N+1 query prevention).
+    /// Includes: Schedule → Section → Course, Subject, Classroom, StudentEnrollments (with Students)
+    /// Note: Regular students (Student.SectionId matches) must be queried separately in the service layer.
+    /// Note: Soft-delete filtering is NOT applied to Schedules in this query.
+    /// Performance: Single query with multiple joins.
+    /// </summary>
+    public async Task<IEnumerable<Schedules>> GetSchedulesWithRelatedDataByInstructorIdAsync(int instructorId)
+    {
+        return await context.Schedules
+            .AsNoTracking()
+            .Where(s => s.InstructorId == instructorId)
+            .Include(s => s.Section)
+                .ThenInclude(sec => sec.Course)
+            .Include(s => s.Subject)
+            .Include(s => s.Classroom)
+            .Include(s => s.Section.StudentEnrollments.Where(se => se.IsActive))
+                .ThenInclude(se => se.Student)
+            .ToListAsync()
+            .ConfigureAwait(false);
+    }
+    #endregion
+
+    #endregion
+
     #region Utility Operations
 
     #region SaveChangesAsync

--- a/attendance_monitoring/Repositories/InstructorRepository.cs
+++ b/attendance_monitoring/Repositories/InstructorRepository.cs
@@ -262,6 +262,8 @@ public class InstructorRepository(ApplicationDbContext context) : IInstructorRep
             .Include(schedule => schedule.Subject)
             .Include(schedule => schedule.Classroom)
             .Include(schedule => schedule.Section)
+                .ThenInclude(section => section.Course)
+            .Include(schedule => schedule.Section)
                 .ThenInclude(section => section.StudentEnrollments.Where(studentEnrollment => studentEnrollment.IsActive))
                     .ThenInclude(studentEnrollment => studentEnrollment.Student)
             .OrderBy(schedule => schedule.DayOfWeek)

--- a/attendance_monitoring/Services/InstructorService.cs
+++ b/attendance_monitoring/Services/InstructorService.cs
@@ -712,6 +712,17 @@ namespace attendance_monitoring.Services
                 {
                     var firstSchedule = sectionGroup.First();
                     var section = firstSchedule.Section;
+                    var regularStudents = (await _instructorRepository.GetRegularStudentsBySectionIdAsync(section.Id).ConfigureAwait(false))
+                        .Select(student => new StudentDto
+                        {
+                            StudentId = student.Id,
+                            StudentUuid = student.Uuid,
+                            Firstname = student.Firstname,
+                            Lastname = student.Lastname,
+                            IsRegular = true,
+                            EnrollmentType = EnrollmentTypeConstants.Regular
+                        })
+                        .ToList();
 
                     // Group schedules by subject within this section
                     var subjectSchedules = sectionGroup
@@ -719,10 +730,10 @@ namespace attendance_monitoring.Services
                         .Select(subjectGroup =>
                         {
                             var schedule = subjectGroup.First();
-                            
-                            // Get all students enrolled in this section through StudentEnrollments
-                            // This includes both regular and irregular students for this specific subject
-                            var enrolledStudents = section.StudentEnrollments
+
+                            // Regular students come from primary section membership.
+                            // Irregular and retake students come from explicit additional enrollments.
+                            var irregularStudents = section.StudentEnrollments
                                 .Where(se => se.SubjectId == schedule.SubjectId 
                                     && !se.Student.IsDeleted
                                     && se.IsActive)
@@ -735,6 +746,11 @@ namespace attendance_monitoring.Services
                                     IsRegular = se.Student.SectionId == section.Id,
                                     EnrollmentType = se.Student.SectionId == section.Id ? "Regular" : se.EnrollmentType
                                 })
+                                .Where(student => !student.IsRegular)
+                                .ToList();
+
+                            var enrolledStudents = regularStudents
+                                .Concat(irregularStudents)
                                 .GroupBy(s => s.StudentId)
                                 .Select(g => g.First())
                                 .OrderBy(s => s.Lastname)

--- a/attendance_monitoring/Services/InstructorService.cs
+++ b/attendance_monitoring/Services/InstructorService.cs
@@ -652,6 +652,155 @@ namespace attendance_monitoring.Services
         }
         #endregion
 
+        #region GetSectionsWithStudentsByInstructorAsync
+        /// <summary>
+        /// Retrieves all sections with students for the current authenticated instructor
+        /// </summary>
+        /// <param name="userPrincipal">The claims principal of the current user</param>
+        /// <returns>Instructor sections with students response DTO</returns>
+        /// <exception cref="T:attendance_monitoring.Exceptions.EntityNotFoundException{System.String}">Thrown when the instructor is not found</exception>
+        /// <exception cref="EntityServiceException">Thrown when an error occurs during retrieval</exception>
+        public async Task<InstructorSectionsWithStudentsResponseDto> GetSectionsWithStudentsByInstructorAsync(ClaimsPrincipal userPrincipal)
+        {
+            try
+            {
+                _logger.LogInformation("Retrieving sections with students for authenticated instructor");
+
+                // Extract user ID from JWT claims
+                var userId = await _userContextService.GetUserIdAsync(userPrincipal).ConfigureAwait(false);
+                if (string.IsNullOrEmpty(userId))
+                {
+                    _logger.LogWarning("User ID not found in JWT claims");
+                    throw new EntityNotFoundException<string>("User", userId ?? "null");
+                }
+
+                // Get instructor by user ID
+                var instructor = await _instructorRepository.GetInstructorByUserIdAsync(userId).ConfigureAwait(false);
+                if (instructor == null)
+                {
+                    _logger.LogWarning("No instructor record found for user ID: {UserId}", userId);
+                    throw new EntityNotFoundException<string>("Instructor", $"UserId: {userId}");
+                }
+
+                _logger.LogInformation("Getting sections with students for instructor ID: {InstructorId}", instructor.Id);
+
+                // Get schedules with related data from repository
+                var schedules = await _instructorRepository.GetSchedulesWithRelatedDataByInstructorIdAsync(instructor.Id).ConfigureAwait(false);
+                var schedulesList = schedules.ToList();
+
+                if (schedulesList.Count == 0)
+                {
+                    _logger.LogInformation("No schedules found for instructor ID: {InstructorId}", instructor.Id);
+                    return new InstructorSectionsWithStudentsResponseDto
+                    {
+                        InstructorId = instructor.Id,
+                        InstructorUuid = instructor.Uuid,
+                        InstructorFirstname = instructor.Firstname,
+                        InstructorLastname = instructor.Lastname,
+                        Sections = new List<SectionWithStudentsDto>()
+                    };
+                }
+
+                // Group schedules by section
+                var sectionGroups = schedulesList
+                    .GroupBy(s => s.SectionId)
+                    .ToList();
+
+                var sectionDtos = new List<SectionWithStudentsDto>();
+
+                foreach (var sectionGroup in sectionGroups)
+                {
+                    var firstSchedule = sectionGroup.First();
+                    var section = firstSchedule.Section;
+
+                    // Group schedules by subject within this section
+                    var subjectSchedules = sectionGroup
+                        .GroupBy(s => s.SubjectId)
+                        .Select(subjectGroup =>
+                        {
+                            var schedule = subjectGroup.First();
+                            
+                            // Get all students enrolled in this section through StudentEnrollments
+                            // This includes both regular and irregular students for this specific subject
+                            var enrolledStudents = section.StudentEnrollments
+                                .Where(se => se.SubjectId == schedule.SubjectId 
+                                    && !se.Student.IsDeleted
+                                    && se.IsActive)
+                                .Select(se => new StudentDto
+                                {
+                                    StudentId = se.Student.Id,
+                                    StudentUuid = se.Student.Uuid,
+                                    Firstname = se.Student.Firstname,
+                                    Lastname = se.Student.Lastname,
+                                    IsRegular = se.Student.SectionId == section.Id,
+                                    EnrollmentType = se.Student.SectionId == section.Id ? "Regular" : se.EnrollmentType
+                                })
+                                .GroupBy(s => s.StudentId)
+                                .Select(g => g.First())
+                                .OrderBy(s => s.Lastname)
+                                .ThenBy(s => s.Firstname)
+                                .ToList();
+
+                            return new SubjectScheduleDto
+                            {
+                                SubjectId = schedule.Subject.Id,
+                                SubjectUuid = schedule.Subject.Uuid,
+                                SubjectName = schedule.Subject.Name,
+                                SubjectCode = schedule.Subject.Code,
+                                ScheduleId = schedule.Id,
+                                ScheduleUuid = schedule.Uuid,
+                                DayOfWeek = schedule.DayOfWeek,
+                                TimeIn = schedule.TimeIn,
+                                TimeOut = schedule.TimeOut,
+                                ClassroomId = schedule.Classroom.Id,
+                                ClassroomUuid = schedule.Classroom.Uuid,
+                                ClassroomName = schedule.Classroom.Name,
+                                Students = enrolledStudents
+                            };
+                        })
+                        .OrderBy(s => s.SubjectName)
+                        .ToList();
+
+                    sectionDtos.Add(new SectionWithStudentsDto
+                    {
+                        SectionId = section.Id,
+                        SectionUuid = section.Uuid,
+                        SectionName = section.Name,
+                        CourseId = section.Course.Id,
+                        CourseUuid = section.Course.Uuid,
+                        CourseName = section.Course.Name,
+                        Subjects = subjectSchedules
+                    });
+                }
+
+                var response = new InstructorSectionsWithStudentsResponseDto
+                {
+                    InstructorId = instructor.Id,
+                    InstructorUuid = instructor.Uuid,
+                    InstructorFirstname = instructor.Firstname,
+                    InstructorLastname = instructor.Lastname,
+                    Sections = sectionDtos.OrderBy(s => s.SectionName).ToList()
+                };
+
+                _logger.LogInformation("Successfully retrieved {SectionCount} sections with students for instructor ID: {InstructorId}",
+                    sectionDtos.Count, instructor.Id);
+
+                return response;
+            }
+            catch (EntityNotFoundException<string>)
+            {
+                // Re-throw EntityNotFoundException as-is
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while retrieving sections with students for authenticated instructor");
+                throw new EntityServiceException("Instructor", "GetSectionsWithStudentsByInstructor",
+                    "An error occurred while retrieving sections with students", ex);
+            }
+        }
+        #endregion
+
         #region Helper Methods
 
         #region IsValidEmail

--- a/attendance_monitoring/Services/InstructorService.cs
+++ b/attendance_monitoring/Services/InstructorService.cs
@@ -817,6 +817,397 @@ namespace attendance_monitoring.Services
         }
         #endregion
 
+        #region GetInstructorSectionsOverviewAsync
+        /// <summary>
+        /// Retrieves a high-level overview of all sections handled by the authenticated instructor.
+        /// </summary>
+        /// <param name="userPrincipal">The claims principal of the current user</param>
+        /// <returns>A list of section overviews with class counts and student counts</returns>
+        /// <exception cref="T:attendance_monitoring.Exceptions.EntityNotFoundException{System.String}">Thrown when the instructor is not found</exception>
+        /// <exception cref="EntityServiceException">Thrown when an error occurs during retrieval</exception>
+        public async Task<List<InstructorSectionOverviewDto>> GetInstructorSectionsOverviewAsync(ClaimsPrincipal userPrincipal)
+        {
+            try
+            {
+                _logger.LogInformation("Retrieving sections overview for authenticated instructor");
+
+                var userId = await _userContextService.GetUserIdAsync(userPrincipal).ConfigureAwait(false);
+                if (string.IsNullOrEmpty(userId))
+                {
+                    _logger.LogWarning("User ID not found in JWT claims");
+                    throw new EntityNotFoundException<string>("User", userId ?? "null");
+                }
+
+                var instructor = await _instructorRepository.GetInstructorByUserIdAsync(userId).ConfigureAwait(false);
+                if (instructor == null)
+                {
+                    _logger.LogWarning("No instructor record found for user ID: {UserId}", userId);
+                    throw new EntityNotFoundException<string>("Instructor", $"UserId: {userId}");
+                }
+
+                _logger.LogInformation("Getting handled sections for instructor ID: {InstructorId}", instructor.Id);
+
+                var sections = await _instructorRepository.GetHandledSectionsByInstructorIdAsync(instructor.Id).ConfigureAwait(false);
+                var sectionList = sections.ToList();
+
+                var overviewDtos = new List<InstructorSectionOverviewDto>();
+
+                foreach (var section in sectionList)
+                {
+                    var schedules = await _instructorRepository.GetHandledClassesBySectionAndInstructorAsync(section.Id, instructor.Id).ConfigureAwait(false);
+                    var handledClassCount = schedules.Select(s => s.SubjectId).Distinct().Count();
+
+                    var regularStudents = await _instructorRepository.GetRegularStudentsBySectionIdAsync(section.Id).ConfigureAwait(false);
+                    var uniqueStudentCount = regularStudents.Count();
+
+                    overviewDtos.Add(new InstructorSectionOverviewDto
+                    {
+                        SectionId = section.Id,
+                        SectionUuid = section.Uuid,
+                        SectionName = section.Name,
+                        CourseId = section.Course.Id,
+                        CourseUuid = section.Course.Uuid,
+                        CourseName = section.Course.Name,
+                        HandledClassCount = handledClassCount,
+                        UniqueStudentCount = uniqueStudentCount
+                    });
+                }
+
+                _logger.LogInformation("Successfully retrieved {SectionCount} section overviews for instructor ID: {InstructorId}",
+                    overviewDtos.Count, instructor.Id);
+
+                return overviewDtos.OrderBy(s => s.SectionName).ToList();
+            }
+            catch (EntityNotFoundException<string>)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while retrieving sections overview for authenticated instructor");
+                throw new EntityServiceException("Instructor", "GetInstructorSectionsOverview",
+                    "An error occurred while retrieving sections overview", ex);
+            }
+        }
+        #endregion
+
+        #region GetInstructorSectionDetailAsync
+        /// <summary>
+        /// Retrieves detailed information about a specific section handled by the authenticated instructor.
+        /// </summary>
+        /// <param name="userPrincipal">The claims principal of the current user</param>
+        /// <param name="sectionId">The section ID to retrieve details for</param>
+        /// <returns>Detailed section information including handled classes and home section students</returns>
+        /// <exception cref="T:attendance_monitoring.Exceptions.EntityNotFoundException{System.String}">Thrown when the instructor is not found</exception>
+        /// <exception cref="EntityUnauthorizedException">Thrown when the instructor is not authorized to view the section</exception>
+        /// <exception cref="EntityServiceException">Thrown when an error occurs during retrieval</exception>
+        public async Task<InstructorSectionDetailDto> GetInstructorSectionDetailAsync(ClaimsPrincipal userPrincipal, int sectionId)
+        {
+            try
+            {
+                _logger.LogInformation("Retrieving section detail for section ID: {SectionId}", sectionId);
+
+                var userId = await _userContextService.GetUserIdAsync(userPrincipal).ConfigureAwait(false);
+                if (string.IsNullOrEmpty(userId))
+                {
+                    _logger.LogWarning("User ID not found in JWT claims");
+                    throw new EntityNotFoundException<string>("User", userId ?? "null");
+                }
+
+                var instructor = await _instructorRepository.GetInstructorByUserIdAsync(userId).ConfigureAwait(false);
+                if (instructor == null)
+                {
+                    _logger.LogWarning("No instructor record found for user ID: {UserId}", userId);
+                    throw new EntityNotFoundException<string>("Instructor", $"UserId: {userId}");
+                }
+
+                var isHandlingSection = await _instructorRepository.IsInstructorHandlingSectionAsync(instructor.Id, sectionId).ConfigureAwait(false);
+                if (!isHandlingSection)
+                {
+                    _logger.LogWarning("Instructor ID {InstructorId} is not authorized to view section ID: {SectionId}", instructor.Id, sectionId);
+                    throw new EntityUnauthorizedException("Section", $"View section with ID {sectionId}", userId, "You are not authorized to view this section");
+                }
+
+                var schedules = await _instructorRepository.GetHandledClassesBySectionAndInstructorAsync(sectionId, instructor.Id).ConfigureAwait(false);
+                var schedulesList = schedules.ToList();
+
+                var section = schedulesList.FirstOrDefault()?.Section;
+                if (section == null)
+                {
+                    var handledSections = await _instructorRepository.GetHandledSectionsByInstructorIdAsync(instructor.Id).ConfigureAwait(false);
+                    section = handledSections.FirstOrDefault(s => s.Id == sectionId);
+                }
+
+                if (section == null)
+                {
+                    _logger.LogWarning("Section with ID {SectionId} not found", sectionId);
+                    throw new EntityNotFoundException<int>("Section", sectionId);
+                }
+
+                var handledClasses = new List<InstructorHandledClassDto>();
+
+                foreach (var scheduleGroup in schedulesList.GroupBy(s => s.SubjectId))
+                {
+                    var schedule = scheduleGroup.First();
+
+                    var regularStudents = (await _instructorRepository.GetRegularStudentsBySectionIdAsync(sectionId).ConfigureAwait(false))
+                        .Select(student => new InstructorHandledClassStudentDto
+                        {
+                            StudentId = student.Id,
+                            StudentUuid = student.Uuid,
+                            Firstname = student.Firstname,
+                            Lastname = student.Lastname,
+                            IsRegular = true,
+                            EnrollmentType = EnrollmentTypeConstants.Regular
+                        })
+                        .ToList();
+
+                    var irregularStudents = section.StudentEnrollments
+                        .Where(se => se.SubjectId == schedule.SubjectId && !se.Student.IsDeleted && se.IsActive)
+                        .Select(se => new InstructorHandledClassStudentDto
+                        {
+                            StudentId = se.Student.Id,
+                            StudentUuid = se.Student.Uuid,
+                            Firstname = se.Student.Firstname,
+                            Lastname = se.Student.Lastname,
+                            IsRegular = se.Student.SectionId == sectionId,
+                            EnrollmentType = se.Student.SectionId == sectionId ? EnrollmentTypeConstants.Regular : se.EnrollmentType
+                        })
+                        .Where(student => !student.IsRegular)
+                        .ToList();
+
+                    var allStudents = regularStudents
+                        .Concat(irregularStudents)
+                        .GroupBy(s => s.StudentId)
+                        .Select(g => g.First())
+                        .OrderBy(s => s.Lastname)
+                        .ThenBy(s => s.Firstname)
+                        .ToList();
+
+                    handledClasses.Add(new InstructorHandledClassDto
+                    {
+                        SubjectId = schedule.Subject.Id,
+                        SubjectUuid = schedule.Subject.Uuid,
+                        SubjectName = schedule.Subject.Name,
+                        SubjectCode = schedule.Subject.Code,
+                        ScheduleId = schedule.Id,
+                        ScheduleUuid = schedule.Uuid,
+                        DayOfWeek = schedule.DayOfWeek,
+                        TimeIn = schedule.TimeIn,
+                        TimeOut = schedule.TimeOut,
+                        ClassroomId = schedule.Classroom.Id,
+                        ClassroomUuid = schedule.Classroom.Uuid,
+                        ClassroomName = schedule.Classroom.Name,
+                        StudentCount = allStudents.Count,
+                        Students = allStudents
+                    });
+                }
+
+                var homeSectionStudents = await _instructorRepository.GetHomeSectionStudentsAsync(sectionId).ConfigureAwait(false);
+                var homeSectionStudentDtos = homeSectionStudents.Select(student => new InstructorHomeSectionStudentDto
+                {
+                    StudentId = student.Id,
+                    StudentUuid = student.Uuid,
+                    Firstname = student.Firstname,
+                    Lastname = student.Lastname,
+                    IsRegular = student.SectionId == sectionId,
+                    EnrollmentType = student.SectionId == sectionId ? EnrollmentTypeConstants.Regular : EnrollmentTypeConstants.Irregular
+                }).ToList();
+
+                var detailDto = new InstructorSectionDetailDto
+                {
+                    SectionId = section.Id,
+                    SectionUuid = section.Uuid,
+                    SectionName = section.Name,
+                    CourseId = section.Course.Id,
+                    CourseUuid = section.Course.Uuid,
+                    CourseName = section.Course.Name,
+                    HandledClassCount = handledClasses.Count,
+                    HomeSectionStudentCount = homeSectionStudentDtos.Count,
+                    HandledClasses = handledClasses.OrderBy(h => h.SubjectName).ToList(),
+                    HomeSectionStudents = homeSectionStudentDtos.OrderBy(s => s.Lastname).ThenBy(s => s.Firstname).ToList()
+                };
+
+                _logger.LogInformation("Successfully retrieved section detail for section ID: {SectionId}, instructor ID: {InstructorId}",
+                    sectionId, instructor.Id);
+
+                return detailDto;
+            }
+            catch (EntityNotFoundException<string>)
+            {
+                throw;
+            }
+            catch (EntityNotFoundException<int>)
+            {
+                throw;
+            }
+            catch (EntityUnauthorizedException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while retrieving section detail for section ID: {SectionId}", sectionId);
+                throw new EntityServiceException("Instructor", $"GetInstructorSectionDetail: {sectionId}",
+                    "An error occurred while retrieving section detail", ex);
+            }
+        }
+        #endregion
+
+        #region GetInstructorStudentDetailAsync
+        /// <summary>
+        /// Retrieves detailed information about a specific student visible to the authenticated instructor.
+        /// </summary>
+        /// <param name="userPrincipal">The claims principal of the current user</param>
+        /// <param name="studentId">The student ID to retrieve details for</param>
+        /// <returns>Detailed student information including enrollments and attendance summary</returns>
+        /// <exception cref="T:attendance_monitoring.Exceptions.EntityNotFoundException{System.String}">Thrown when the instructor is not found</exception>
+        /// <exception cref="T:attendance_monitoring.Exceptions.EntityNotFoundException{System.Int32}">Thrown when the student is not found</exception>
+        /// <exception cref="EntityUnauthorizedException">Thrown when the instructor is not authorized to view the student</exception>
+        /// <exception cref="EntityServiceException">Thrown when an error occurs during retrieval</exception>
+        public async Task<InstructorStudentDetailDto> GetInstructorStudentDetailAsync(ClaimsPrincipal userPrincipal, int studentId)
+        {
+            try
+            {
+                _logger.LogInformation("Retrieving student detail for student ID: {StudentId}", studentId);
+
+                var userId = await _userContextService.GetUserIdAsync(userPrincipal).ConfigureAwait(false);
+                if (string.IsNullOrEmpty(userId))
+                {
+                    _logger.LogWarning("User ID not found in JWT claims");
+                    throw new EntityNotFoundException<string>("User", userId ?? "null");
+                }
+
+                var instructor = await _instructorRepository.GetInstructorByUserIdAsync(userId).ConfigureAwait(false);
+                if (instructor == null)
+                {
+                    _logger.LogWarning("No instructor record found for user ID: {UserId}", userId);
+                    throw new EntityNotFoundException<string>("Instructor", $"UserId: {userId}");
+                }
+
+                var student = await _instructorRepository.GetStudentWithDetailsAsync(studentId).ConfigureAwait(false);
+                if (student == null)
+                {
+                    _logger.LogWarning("Student with ID {StudentId} not found", studentId);
+                    throw new EntityNotFoundException<int>("Student", studentId);
+                }
+
+                var isStudentVisible = await IsStudentVisibleToInstructorAsync(instructor.Id, student).ConfigureAwait(false);
+                if (!isStudentVisible)
+                {
+                    _logger.LogWarning("Instructor ID {InstructorId} is not authorized to view student ID: {StudentId}", instructor.Id, studentId);
+                    throw new EntityUnauthorizedException("Student", $"View student with ID {studentId}", userId, "You are not authorized to view this student");
+                }
+
+                // Build home-section enrollments from schedules taught by this instructor
+                var instructorSchedules = await _instructorRepository
+                    .GetHandledClassesBySectionAndInstructorAsync(student.SectionId, instructor.Id)
+                    .ConfigureAwait(false);
+
+                var homeSectionEnrollments = instructorSchedules
+                    .GroupBy(schedule => schedule.SubjectId)
+                    .Select(group => group.First())
+                    .Select(schedule => new InstructorStudentEnrollmentDto
+                    {
+                        SubjectId = schedule.SubjectId,
+                        SubjectName = schedule.Subject.Name,
+                        SubjectCode = schedule.Subject.Code,
+                        SectionId = schedule.SectionId,
+                        SectionName = schedule.Section.Name,
+                        EnrollmentType = EnrollmentTypeConstants.Regular
+                    });
+
+                var additionalEnrollments = student.AdditionalEnrollments
+                    .Where(se => se.IsActive)
+                    .Select(se => new InstructorStudentEnrollmentDto
+                    {
+                        SubjectId = se.SubjectId,
+                        SubjectName = se.Subject.Name,
+                        SubjectCode = se.Subject.Code,
+                        SectionId = se.SectionId,
+                        SectionName = se.Section.Name,
+                        EnrollmentType = se.EnrollmentType
+                    });
+
+                var enrollments = homeSectionEnrollments
+                    .Concat(additionalEnrollments)
+                    .ToList();
+
+                var attendanceRecords = await _instructorRepository.GetStudentAttendanceForInstructorSubjectsAsync(studentId, instructor.Id).ConfigureAwait(false);
+                var attendanceList = attendanceRecords.ToList();
+
+                var totalSessions = attendanceList.Count;
+                var presentCount = attendanceList.Count(ar => ar.Status == "Present");
+                var absentCount = attendanceList.Count(ar => ar.Status == "Absent");
+                var lateCount = attendanceList.Count(ar => ar.Status == "Late");
+                var attendanceRate = totalSessions > 0 ? (double)(presentCount + lateCount) / totalSessions * 100 : 0;
+
+                var detailDto = new InstructorStudentDetailDto
+                {
+                    StudentId = student.Id,
+                    StudentUuid = student.Uuid,
+                    Firstname = student.Firstname,
+                    Lastname = student.Lastname,
+                    SectionId = student.SectionId,
+                    SectionName = student.Section?.Name,
+                    CourseId = student.Section?.CourseId,
+                    CourseName = student.Section?.Course?.Name,
+                    IsRegular = student.IsRegular,
+                    EnrollmentType = student.IsRegular ? EnrollmentTypeConstants.Regular : EnrollmentTypeConstants.Irregular,
+                    Enrollments = enrollments,
+                    AttendanceSummary = new InstructorStudentAttendanceSummaryDto
+                    {
+                        TotalSessions = totalSessions,
+                        PresentCount = presentCount,
+                        AbsentCount = absentCount,
+                        LateCount = lateCount,
+                        AttendanceRate = Math.Round(attendanceRate, 2)
+                    }
+                };
+
+                _logger.LogInformation("Successfully retrieved student detail for student ID: {StudentId}, instructor ID: {InstructorId}",
+                    studentId, instructor.Id);
+
+                return detailDto;
+            }
+            catch (EntityNotFoundException<string>)
+            {
+                throw;
+            }
+            catch (EntityNotFoundException<int>)
+            {
+                throw;
+            }
+            catch (EntityUnauthorizedException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error occurred while retrieving student detail for student ID: {StudentId}", studentId);
+                throw new EntityServiceException("Instructor", $"GetInstructorStudentDetail: {studentId}",
+                    "An error occurred while retrieving student detail", ex);
+            }
+        }
+
+        private async Task<bool> IsStudentVisibleToInstructorAsync(int instructorId, Student student)
+        {
+            var isHandlingStudentSection = await _instructorRepository.IsInstructorHandlingSectionAsync(instructorId, student.SectionId).ConfigureAwait(false);
+            if (isHandlingStudentSection)
+            {
+                return true;
+            }
+
+            var handledSections = await _instructorRepository.GetHandledSectionsByInstructorIdAsync(instructorId).ConfigureAwait(false);
+            var handledSectionIds = handledSections.Select(s => s.Id).ToHashSet();
+
+            var hasActiveEnrollmentInHandledSection = student.AdditionalEnrollments
+                .Any(se => se.IsActive && handledSectionIds.Contains(se.SectionId));
+
+            return hasActiveEnrollmentInHandledSection;
+        }
+        #endregion
+
         #region Helper Methods
 
         #region IsValidEmail

--- a/attendance_monitoring/Services/InstructorService.cs
+++ b/attendance_monitoring/Services/InstructorService.cs
@@ -695,8 +695,8 @@ namespace attendance_monitoring.Services
                     {
                         InstructorId = instructor.Id,
                         InstructorUuid = instructor.Uuid,
-                        InstructorFirstname = instructor.Firstname,
-                        InstructorLastname = instructor.Lastname,
+                        InstructorFirstname = instructor.Firstname ?? string.Empty,
+                        InstructorLastname = instructor.Lastname ?? string.Empty,
                         Sections = new List<SectionWithStudentsDto>()
                     };
                 }
@@ -736,17 +736,17 @@ namespace attendance_monitoring.Services
                             var irregularStudents = section.StudentEnrollments
                                 .Where(se => se.SubjectId == schedule.SubjectId 
                                     && !se.Student.IsDeleted
-                                    && se.IsActive)
+                                    && se.IsActive
+                                    && se.Student.SectionId != section.Id)
                                 .Select(se => new StudentDto
                                 {
                                     StudentId = se.Student.Id,
                                     StudentUuid = se.Student.Uuid,
                                     Firstname = se.Student.Firstname,
                                     Lastname = se.Student.Lastname,
-                                    IsRegular = se.Student.SectionId == section.Id,
-                                    EnrollmentType = se.Student.SectionId == section.Id ? "Regular" : se.EnrollmentType
+                                    IsRegular = false,
+                                    EnrollmentType = se.EnrollmentType
                                 })
-                                .Where(student => !student.IsRegular)
                                 .ToList();
 
                             var enrolledStudents = regularStudents
@@ -793,8 +793,8 @@ namespace attendance_monitoring.Services
                 {
                     InstructorId = instructor.Id,
                     InstructorUuid = instructor.Uuid,
-                    InstructorFirstname = instructor.Firstname,
-                    InstructorLastname = instructor.Lastname,
+                    InstructorFirstname = instructor.Firstname ?? string.Empty,
+                    InstructorLastname = instructor.Lastname ?? string.Empty,
                     Sections = sectionDtos.OrderBy(s => s.SectionName).ToList()
                 };
 
@@ -855,10 +855,31 @@ namespace attendance_monitoring.Services
                 foreach (var section in sectionList)
                 {
                     var schedules = await _instructorRepository.GetHandledClassesBySectionAndInstructorAsync(section.Id, instructor.Id).ConfigureAwait(false);
-                    var handledClassCount = schedules.Select(s => s.SubjectId).Distinct().Count();
+                    var schedulesList = schedules.ToList();
+                    var handledSubjectIds = schedulesList
+                        .Select(schedule => schedule.SubjectId)
+                        .Distinct()
+                        .ToHashSet();
+                    var handledClassCount = handledSubjectIds.Count;
 
-                    var regularStudents = await _instructorRepository.GetRegularStudentsBySectionIdAsync(section.Id).ConfigureAwait(false);
-                    var uniqueStudentCount = regularStudents.Count();
+                    var uniqueStudentCount = 0;
+                    if (handledClassCount > 0)
+                    {
+                        var regularStudents = await _instructorRepository.GetRegularStudentsBySectionIdAsync(section.Id).ConfigureAwait(false);
+                        var regularStudentIds = regularStudents.Select(student => student.Id);
+                        var sectionWithEnrollments = schedulesList.First().Section;
+                        var irregularStudentIds = sectionWithEnrollments.StudentEnrollments
+                            .Where(enrollment => handledSubjectIds.Contains(enrollment.SubjectId)
+                                && enrollment.IsActive
+                                && !enrollment.Student.IsDeleted
+                                && enrollment.Student.SectionId != section.Id)
+                            .Select(enrollment => enrollment.StudentId);
+
+                        uniqueStudentCount = regularStudentIds
+                            .Concat(irregularStudentIds)
+                            .Distinct()
+                            .Count();
+                    }
 
                     overviewDtos.Add(new InstructorSectionOverviewDto
                     {
@@ -945,35 +966,36 @@ namespace attendance_monitoring.Services
                 }
 
                 var handledClasses = new List<InstructorHandledClassDto>();
+                var regularStudents = (await _instructorRepository.GetRegularStudentsBySectionIdAsync(sectionId).ConfigureAwait(false))
+                    .Select(student => new InstructorHandledClassStudentDto
+                    {
+                        StudentId = student.Id,
+                        StudentUuid = student.Uuid,
+                        Firstname = student.Firstname,
+                        Lastname = student.Lastname,
+                        IsRegular = true,
+                        EnrollmentType = EnrollmentTypeConstants.Regular
+                    })
+                    .ToList();
 
                 foreach (var scheduleGroup in schedulesList.GroupBy(s => s.SubjectId))
                 {
                     var schedule = scheduleGroup.First();
 
-                    var regularStudents = (await _instructorRepository.GetRegularStudentsBySectionIdAsync(sectionId).ConfigureAwait(false))
-                        .Select(student => new InstructorHandledClassStudentDto
-                        {
-                            StudentId = student.Id,
-                            StudentUuid = student.Uuid,
-                            Firstname = student.Firstname,
-                            Lastname = student.Lastname,
-                            IsRegular = true,
-                            EnrollmentType = EnrollmentTypeConstants.Regular
-                        })
-                        .ToList();
-
                     var irregularStudents = section.StudentEnrollments
-                        .Where(se => se.SubjectId == schedule.SubjectId && !se.Student.IsDeleted && se.IsActive)
+                        .Where(se => se.SubjectId == schedule.SubjectId
+                            && !se.Student.IsDeleted
+                            && se.IsActive
+                            && se.Student.SectionId != sectionId)
                         .Select(se => new InstructorHandledClassStudentDto
                         {
                             StudentId = se.Student.Id,
                             StudentUuid = se.Student.Uuid,
                             Firstname = se.Student.Firstname,
                             Lastname = se.Student.Lastname,
-                            IsRegular = se.Student.SectionId == sectionId,
-                            EnrollmentType = se.Student.SectionId == sectionId ? EnrollmentTypeConstants.Regular : se.EnrollmentType
+                            IsRegular = false,
+                            EnrollmentType = se.EnrollmentType
                         })
-                        .Where(student => !student.IsRegular)
                         .ToList();
 
                     var allStudents = regularStudents

--- a/attendance_monitoring/Services/InstructorService.cs
+++ b/attendance_monitoring/Services/InstructorService.cs
@@ -1220,13 +1220,14 @@ namespace attendance_monitoring.Services
                 return true;
             }
 
-            var handledSections = await _instructorRepository.GetHandledSectionsByInstructorIdAsync(instructorId).ConfigureAwait(false);
-            var handledSectionIds = handledSections.Select(s => s.Id).ToHashSet();
+            var instructorSchedules = await _scheduleRepository.GetSchedulesByInstructorIdAsync(instructorId).ConfigureAwait(false);
+            var handledSectionSubjectPairs = instructorSchedules
+                .Select(schedule => (schedule.SectionId, schedule.SubjectId))
+                .ToHashSet();
 
-            var hasActiveEnrollmentInHandledSection = student.AdditionalEnrollments
-                .Any(se => se.IsActive && handledSectionIds.Contains(se.SectionId));
-
-            return hasActiveEnrollmentInHandledSection;
+            return student.AdditionalEnrollments.Any(studentEnrollment =>
+                studentEnrollment.IsActive
+                && handledSectionSubjectPairs.Contains((studentEnrollment.SectionId, studentEnrollment.SubjectId)));
         }
         #endregion
 

--- a/attendance_monitoring/Services/InstructorService.cs
+++ b/attendance_monitoring/Services/InstructorService.cs
@@ -19,6 +19,7 @@ namespace attendance_monitoring.Services
     public class InstructorService : IInstructorService
     {
         private readonly IInstructorRepository _instructorRepository;
+        private readonly ISectionRepository _sectionRepository;
         private readonly IScheduleRepository _scheduleRepository;
         private readonly IUserContextService _userContextService;
         private readonly ILogger<InstructorService> _logger;
@@ -27,12 +28,14 @@ namespace attendance_monitoring.Services
         /// Initializes a new instance of the InstructorService class
         /// </summary>
         /// <param name="instructorRepository">Repository for instructor data operations</param>
+        /// <param name="sectionRepository">Repository for section data operations</param>
         /// <param name="scheduleRepository">Repository for schedule data operations</param>
         /// <param name="userContextService">Service for managing user context and authorization</param>
         /// <param name="logger">Logger for logging operations</param>
-        public InstructorService(IInstructorRepository instructorRepository, IScheduleRepository scheduleRepository, IUserContextService userContextService, ILogger<InstructorService> logger)
+        public InstructorService(IInstructorRepository instructorRepository, ISectionRepository sectionRepository, IScheduleRepository scheduleRepository, IUserContextService userContextService, ILogger<InstructorService> logger)
         {
             _instructorRepository = instructorRepository ?? throw new ArgumentNullException(nameof(instructorRepository));
+            _sectionRepository = sectionRepository ?? throw new ArgumentNullException(nameof(sectionRepository));
             _scheduleRepository = scheduleRepository ?? throw new ArgumentNullException(nameof(scheduleRepository));
             _userContextService = userContextService ?? throw new ArgumentNullException(nameof(userContextService));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -940,6 +943,13 @@ namespace attendance_monitoring.Services
                 {
                     _logger.LogWarning("No instructor record found for user ID: {UserId}", userId);
                     throw new EntityNotFoundException<string>("Instructor", $"UserId: {userId}");
+                }
+
+                var sectionExists = await _sectionRepository.GetSectionByIdAsync(sectionId).ConfigureAwait(false);
+                if (sectionExists == null)
+                {
+                    _logger.LogWarning("Section with ID {SectionId} not found", sectionId);
+                    throw new EntityNotFoundException<int>("Section", sectionId);
                 }
 
                 var isHandlingSection = await _instructorRepository.IsInstructorHandlingSectionAsync(instructor.Id, sectionId).ConfigureAwait(false);

--- a/attendance_monitoring/Services/StudentEnrollmentService.cs
+++ b/attendance_monitoring/Services/StudentEnrollmentService.cs
@@ -1,4 +1,5 @@
 using attendance_monitoring.Classes;
+using attendance_monitoring.Constants;
 using attendance_monitoring.IRepository;
 using attendance_monitoring.IServices;
 using attendance_monitoring.Exceptions;
@@ -31,6 +32,13 @@ public class StudentEnrollmentService : IStudentEnrollmentService
     {
         try
         {
+            if (!EnrollmentTypeConstants.IsValid(enrollmentType))
+            {
+                throw new ValidationException($"Enrollment type must be one of: {string.Join(", ", EnrollmentTypeConstants.All)}");
+            }
+
+            var normalizedEnrollmentType = EnrollmentTypeConstants.Normalize(enrollmentType);
+
             // Validate student exists
             var student = await _studentRepository.GetStudentByIdAsync(studentId);
             if (student == null || student.IsDeleted)
@@ -73,7 +81,7 @@ public class StudentEnrollmentService : IStudentEnrollmentService
                 StudentId = studentId,
                 SectionId = sectionId,
                 SubjectId = subjectId,
-                EnrollmentType = enrollmentType,
+                EnrollmentType = normalizedEnrollmentType,
                 AcademicYear = academicYear,
                 Semester = semester,
                 IsActive = true
@@ -81,7 +89,7 @@ public class StudentEnrollmentService : IStudentEnrollmentService
 
             return await _enrollmentRepository.CreateAsync(enrollment);
         }
-        catch (Exception ex) when (ex is not EntityNotFoundException<int> and not EntityAlreadyExistsException<string>)
+        catch (Exception ex) when (ex is not ValidationException and not EntityNotFoundException<int> and not EntityAlreadyExistsException<string>)
         {
             _logger.LogError(ex,
                 "Enrollment operation failed for student {StudentId}, section {SectionId}, subject {SubjectId}",

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -221,6 +221,65 @@ Get current instructor's profile (requires Teacher role).
 ### GET /api/instructors/{instructorId}/subjects
 Get all subjects assigned to an instructor.
 
+### GET /api/instructors/me/sections-with-students
+Get all sections with enrolled students for the authenticated instructor.
+
+**Authorization:** Requires `PrivilegedPolicy` (Instructor role)
+
+**Response:**
+```json
+{
+  "instructorId": 1,
+  "instructorUuid": "guid",
+  "instructorFirstname": "John",
+  "instructorLastname": "Doe",
+  "sections": [
+    {
+      "sectionId": 1,
+      "sectionUuid": "guid",
+      "sectionName": "BSCS 3A",
+      "courseId": 1,
+      "courseUuid": "guid",
+      "courseName": "Bachelor of Science in Computer Science",
+      "subjects": [
+        {
+          "subjectId": 1,
+          "subjectUuid": "guid",
+          "subjectName": "Data Structures",
+          "subjectCode": "CS301",
+          "scheduleId": 1,
+          "scheduleUuid": "guid",
+          "dayOfWeek": "Monday",
+          "timeIn": "08:00:00",
+          "timeOut": "10:00:00",
+          "classroomId": 1,
+          "classroomUuid": "guid",
+          "classroomName": "Room 101",
+          "students": [
+            {
+              "studentId": 1,
+              "studentUuid": "guid",
+              "firstname": "Alice",
+              "lastname": "Smith",
+              "isRegular": true,
+              "enrollmentType": "Regular"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Notes:**
+- Returns empty sections array if instructor has no schedules
+- Includes both regular and irregular students enrolled via StudentEnrollments
+- Regular students are those where `Student.SectionId` matches the section
+- Irregular students are those enrolled via `StudentEnrollment` for specific subjects
+- Soft-deleted students are excluded from the response
+- Inactive enrollments are excluded from the response
+
 ### PATCH /api/instructors/{id}
 Update instructor information.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -221,10 +221,15 @@ Get current instructor's profile (requires Teacher role).
 ### GET /api/instructors/{instructorId}/subjects
 Get all subjects assigned to an instructor.
 
+### GET /api/instructors/me/schedules
+Get the schedules handled by the authenticated privileged user.
+
+**Authorization:** Requires `PrivilegedPolicy` (Admin or Instructor role)
+
 ### GET /api/instructors/me/sections-with-students
 Get all sections with enrolled students for the authenticated instructor.
 
-**Authorization:** Requires `PrivilegedPolicy` (Instructor role)
+**Authorization:** Requires `PrivilegedPolicy` (Admin or Instructor role)
 
 **Response:**
 ```json
@@ -279,6 +284,33 @@ Get all sections with enrolled students for the authenticated instructor.
 - Irregular students are those enrolled via `StudentEnrollment` for specific subjects
 - Soft-deleted students are excluded from the response
 - Inactive enrollments are excluded from the response
+
+### GET /api/instructors/me/sections
+Get an overview of sections handled by the authenticated privileged user.
+
+**Authorization:** Requires `PrivilegedPolicy` (Admin or Instructor role)
+
+**Response fields:**
+- `handledClassCount` - number of distinct subjects handled in the section
+- `uniqueStudentCount` - number of unique regular and active irregular students associated with those handled classes
+
+### GET /api/instructors/me/sections/{sectionId}
+Get detailed section information for a handled section, including handled classes and home-section roster.
+
+**Authorization:** Requires `PrivilegedPolicy` (Admin or Instructor role)
+
+**Error responses:**
+- `404 Not Found` if the instructor profile or section is missing
+- `403 Forbidden` if the authenticated user does not handle the requested section
+
+### GET /api/instructors/me/students/{studentId}
+Get detailed student information visible to the authenticated privileged user.
+
+**Authorization:** Requires `PrivilegedPolicy` (Admin or Instructor role)
+
+**Error responses:**
+- `404 Not Found` if the instructor profile or student is missing
+- `403 Forbidden` if the authenticated user is not allowed to view the requested student
 
 ### PATCH /api/instructors/{id}
 Update instructor information.


### PR DESCRIPTION
----
## Summary by Gitar

- **New endpoints:**
  - Added `/api/instructors/me/sections-with-students` and `/api/instructors/me/sections` to retrieve instructor-specific class data.
  - Added `/api/instructors/me/sections/{sectionId}` and `/api/instructors/me/students/{studentId}` for detailed drilldown views.
- **Validation & Constants:**
  - Introduced `EnrollmentTypeConstants` to standardize enrollment categories and added request validation for `CreateStudentEnrollment`.
- **Testing:**
  - Implemented `InstructorSectionsIntegrationTests` and repository unit tests to ensure correct data retrieval and N+1 query prevention.

<sub>This will update automatically on new commits.</sub>