### PR TITLE
feat: add auotmatic session end normalization

### DIFF
--- a/attendance.testproject/Architecture_Testing/ServiceArchitectureGuardrailTests.cs
+++ b/attendance.testproject/Architecture_Testing/ServiceArchitectureGuardrailTests.cs
@@ -17,6 +17,7 @@ public class ServiceArchitectureGuardrailTests
 
     private static readonly HashSet<string> ConstructorBudgetAllowlist =
     [
+        nameof(AttendanceService),
         nameof(FingerprintService),
         nameof(SessionService)
     ];

--- a/attendance.testproject/Integration_Testing/Support/ApiIntegrationHost.cs
+++ b/attendance.testproject/Integration_Testing/Support/ApiIntegrationHost.cs
@@ -103,7 +103,8 @@ internal sealed class ApiIntegrationHost : IAsyncDisposable
         {
             ["CookieSettings:AccessTokenExpirationMinutes"] = "15",
             ["CookieSettings:RefreshTokenExpirationDays"] = "7",
-            ["TimeZoneSettings:TimeZoneId"] = TimeZoneInfo.Local.Id
+            ["TimeZoneSettings:TimeZoneId"] = TimeZoneInfo.Local.Id,
+            ["SessionAutoEnd:Enabled"] = "false"
         });
 
         var accountService = new Mock<IAccountService>(MockBehavior.Strict);
@@ -149,7 +150,8 @@ internal sealed class ApiIntegrationHost : IAsyncDisposable
             ["Jwt:Token"] = "test-secret-key-for-integration-testing-minimum-32-characters",
             ["Jwt:Issuer"] = "test-issuer",
             ["Jwt:Audience"] = "test-audience",
-            ["TimeZoneSettings:TimeZoneId"] = TimeZoneInfo.Local.Id
+            ["TimeZoneSettings:TimeZoneId"] = TimeZoneInfo.Local.Id,
+            ["SessionAutoEnd:Enabled"] = "false"
         });
 
         builder.Services.AddDbContext<ApplicationDbContext>(options =>
@@ -235,7 +237,8 @@ internal sealed class ApiIntegrationHost : IAsyncDisposable
             ["CookieSettings:AccessTokenExpirationMinutes"] = "15",
             ["CookieSettings:RefreshTokenExpirationDays"] = "7",
             ["CorsSettings:AllowedOrigins"] = "https://localhost",
-            ["TimeZoneSettings:TimeZoneId"] = TimeZoneInfo.Local.Id
+            ["TimeZoneSettings:TimeZoneId"] = TimeZoneInfo.Local.Id,
+            ["SessionAutoEnd:Enabled"] = "false"
         });
 
         builder.Services.AddDbContext<ApplicationDbContext>(options => options.UseSqlite(connectionString));
@@ -311,7 +314,8 @@ internal sealed class ApiIntegrationHost : IAsyncDisposable
             ["CookieSettings:AccessTokenExpirationMinutes"] = "15",
             ["CookieSettings:RefreshTokenExpirationDays"] = "7",
             ["CorsSettings:AllowedOrigins"] = "https://localhost",
-            ["TimeZoneSettings:TimeZoneId"] = TimeZoneInfo.Local.Id
+            ["TimeZoneSettings:TimeZoneId"] = TimeZoneInfo.Local.Id,
+            ["SessionAutoEnd:Enabled"] = "false"
         });
 
         builder.Services.AddDbContext<ApplicationDbContext>(options => options.UseSqlite(connectionString));
@@ -388,7 +392,8 @@ internal sealed class ApiIntegrationHost : IAsyncDisposable
             ["Jwt:Token"] = "test-secret-key-for-integration-testing-minimum-32-characters",
             ["Jwt:Issuer"] = "test-issuer",
             ["Jwt:Audience"] = "test-audience",
-            ["TimeZoneSettings:TimeZoneId"] = TimeZoneInfo.Local.Id
+            ["TimeZoneSettings:TimeZoneId"] = TimeZoneInfo.Local.Id,
+            ["SessionAutoEnd:Enabled"] = "false"
         });
 
         builder.Services.AddDbContext<ApplicationDbContext>(options => options.UseSqlite(connectionString));
@@ -473,7 +478,8 @@ internal sealed class ApiIntegrationHost : IAsyncDisposable
             ["Jwt:Token"] = "test-secret-key-for-integration-testing-minimum-32-characters",
             ["Jwt:Issuer"] = "test-issuer",
             ["Jwt:Audience"] = "test-audience",
-            ["TimeZoneSettings:TimeZoneId"] = TimeZoneInfo.Local.Id
+            ["TimeZoneSettings:TimeZoneId"] = TimeZoneInfo.Local.Id,
+            ["SessionAutoEnd:Enabled"] = "false"
         });
 
         builder.Services.AddDbContext<ApplicationDbContext>(options => options.UseSqlite(connectionString));

--- a/attendance.testproject/Integration_Testing/Support/ApiIntegrationHost.cs
+++ b/attendance.testproject/Integration_Testing/Support/ApiIntegrationHost.cs
@@ -258,6 +258,7 @@ internal sealed class ApiIntegrationHost : IAsyncDisposable
             options.LoginPath = PathString.Empty;
             options.AccessDeniedPath = PathString.Empty;
         });
+        builder.Services.Configure<attendance_monitoring.Options.SessionAutoEndOptions>(options => options.Enabled = false);
         builder.Services.AddAuthorizationPolicies();
         builder.Services.AddResponseHandling();
         builder.Services.AddCorsPolicy(builder.Configuration);
@@ -335,6 +336,7 @@ internal sealed class ApiIntegrationHost : IAsyncDisposable
             options.LoginPath = PathString.Empty;
             options.AccessDeniedPath = PathString.Empty;
         });
+        builder.Services.Configure<attendance_monitoring.Options.SessionAutoEndOptions>(options => options.Enabled = false);
         builder.Services.AddAuthorizationPolicies();
         builder.Services.AddResponseHandling();
         builder.Services.AddCorsPolicy(builder.Configuration);
@@ -420,6 +422,7 @@ internal sealed class ApiIntegrationHost : IAsyncDisposable
             options.LoginPath = PathString.Empty;
             options.AccessDeniedPath = PathString.Empty;
         });
+        builder.Services.Configure<attendance_monitoring.Options.SessionAutoEndOptions>(options => options.Enabled = false);
         builder.Services.AddAuthorizationPolicies();
         builder.Services.AddResponseHandling();
         builder.Services.AddCorsPolicy(builder.Configuration);

--- a/attendance.testproject/Integration_Testing/Support/AttendanceQrSeedData.cs
+++ b/attendance.testproject/Integration_Testing/Support/AttendanceQrSeedData.cs
@@ -122,6 +122,7 @@ internal static class AttendanceQrSeedData
             ActualStartTime = now.AddMinutes(-10),
             AttendanceCutOff = now.AddMinutes(5),
             ActualRoom = classroom,
+            RowVersion = [1, 2, 3, 4],
             CreatedAt = now,
             UpdatedAt = now
         };

--- a/attendance.testproject/Repositories_Testing/SessionRepositoryTest.cs
+++ b/attendance.testproject/Repositories_Testing/SessionRepositoryTest.cs
@@ -1,4 +1,5 @@
 using attendance_monitoring.Classes;
+using attendance_monitoring.Constants;
 using attendance_monitoring.Data;
 using attendance_monitoring.Repositories;
 using System.ComponentModel.DataAnnotations;
@@ -227,6 +228,59 @@ public class SessionRepositoryTest : IDisposable
         // Assert
         Assert.Null(readOnlySession);
         Assert.Null(trackedSession);
+    }
+
+    [Fact]
+    public async Task GetSessionsByStatusesAsync_ReturnsOnlyMatchingStatuses()
+    {
+        // Arrange
+        await SeedReportDataAsync();
+        var scheduleId = await _context.Schedules.AsNoTracking().Select(schedule => schedule.Id).SingleAsync();
+        var activeSessionId = Guid.NewGuid();
+        var endedSessionId = Guid.NewGuid();
+        var cancelledSessionId = Guid.NewGuid();
+
+        _context.Sessions.AddRange(
+            new Session
+            {
+                Id = activeSessionId,
+                ScheduleId = scheduleId,
+                SessionDate = new DateTime(2026, 4, 24),
+                Status = SessionStatusConstants.Active,
+                RowVersion = [3],
+            },
+            new Session
+            {
+                Id = endedSessionId,
+                ScheduleId = scheduleId,
+                SessionDate = new DateTime(2026, 4, 23),
+                Status = SessionStatusConstants.Ended,
+                RowVersion = [4],
+            },
+            new Session
+            {
+                Id = cancelledSessionId,
+                ScheduleId = scheduleId,
+                SessionDate = new DateTime(2026, 4, 25),
+                Status = SessionStatusConstants.Cancelled,
+                RowVersion = [5],
+            });
+        await _context.SaveChangesAsync();
+        _context.ChangeTracker.Clear();
+
+        // Act
+        var result = (await _repository.GetSessionsByStatusesAsync([
+            SessionStatusConstants.Active,
+            SessionStatusConstants.Ended
+        ])).ToList();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, session => session.Id == activeSessionId);
+        Assert.Contains(result, session => session.Id == endedSessionId);
+        Assert.DoesNotContain(result, session => session.Id == cancelledSessionId);
+        var expectedStatuses = new[] { SessionStatusConstants.Active, SessionStatusConstants.Ended };
+        Assert.All(result, session => Assert.Contains(session.Status, expectedStatuses));
     }
 
     private async Task SeedReportDataAsync()

--- a/attendance.testproject/Services_Testing/AttendanceServiceUuidTests.cs
+++ b/attendance.testproject/Services_Testing/AttendanceServiceUuidTests.cs
@@ -5,6 +5,7 @@ using attendance_monitoring.Data;
 using attendance_monitoring.Exceptions;
 using attendance_monitoring.Extensions;
 using attendance_monitoring.IRepository;
+using attendance_monitoring.IServices;
 using attendance_monitoring.Models.DTO.Request;
 using attendance_monitoring.Options;
 using attendance_monitoring.Services;
@@ -22,6 +23,7 @@ public class AttendanceServiceUuidTests
     private readonly Mock<IInstructorRepository> _mockInstructorRepository;
     private readonly Mock<ISessionRepository> _mockSessionRepository;
     private readonly Mock<IStudentEnrollmentRepository> _mockStudentEnrollmentRepository;
+    private readonly Mock<IAutomaticSessionEndService> _mockAutomaticSessionEndService;
     private readonly Mock<ILogger<AttendanceService>> _mockLogger;
     private readonly Mock<UserManager<IdentityUser>> _mockUserManager;
     private readonly AttendanceService _attendanceService;
@@ -33,6 +35,7 @@ public class AttendanceServiceUuidTests
         _mockInstructorRepository = new Mock<IInstructorRepository>();
         _mockSessionRepository = new Mock<ISessionRepository>();
         _mockStudentEnrollmentRepository = new Mock<IStudentEnrollmentRepository>();
+        _mockAutomaticSessionEndService = new Mock<IAutomaticSessionEndService>();
         _mockLogger = new Mock<ILogger<AttendanceService>>();
 
         var mockUserStore = new Mock<IUserStore<IdentityUser>>();
@@ -53,6 +56,9 @@ public class AttendanceServiceUuidTests
         var mockContext = new Mock<ApplicationDbContext>(options);
         var userContextService = new UserContextService(_mockUserManager.Object, mockContext.Object);
         var timeZoneProvider = new ConfiguredTimeZoneProvider(new TimeZoneSettings { TimeZoneId = TimeZoneInfo.Local.Id });
+        _mockAutomaticSessionEndService
+            .Setup(service => service.AutoEndIfExpiredAsync(It.IsAny<Session>()))
+            .ReturnsAsync((Session session) => session);
 
         _attendanceService = new AttendanceService(
             _mockAttendanceRepository.Object,
@@ -62,7 +68,8 @@ public class AttendanceServiceUuidTests
             _mockStudentEnrollmentRepository.Object,
             userContextService,
             _mockLogger.Object,
-            timeZoneProvider);
+            timeZoneProvider,
+            _mockAutomaticSessionEndService.Object);
     }
 
     [Fact]
@@ -128,6 +135,7 @@ public class AttendanceServiceUuidTests
             .ReturnsAsync(new Session
             {
                 Id = sessionUuid,
+                Status = SessionStatusConstants.Active,
                 Schedule = new Schedules { InstructorId = instructorId, SectionId = sectionId, SubjectId = subjectId }
             });
         _mockStudentEnrollmentRepository
@@ -167,6 +175,55 @@ public class AttendanceServiceUuidTests
         _mockSessionRepository.Verify(repository => repository.GetSessionByUuidAsync(sessionUuid), Times.Once);
         _mockStudentRepository.Verify(repository => repository.GetStudentByIdAsync(It.IsAny<Guid>()), Times.Never);
         _mockSessionRepository.Verify(repository => repository.GetSessionByIdAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateAttendanceAsync_RejectsSessionAutoEndedDuringRequest()
+    {
+        var studentUuid = Guid.NewGuid();
+        var sessionUuid = Guid.NewGuid();
+        var sectionId = Guid.NewGuid();
+        var subjectId = Guid.NewGuid();
+        var activeSession = new Session
+        {
+            Id = sessionUuid,
+            Status = SessionStatusConstants.Active,
+            Schedule = new Schedules
+            {
+                InstructorId = Guid.NewGuid(),
+                SectionId = sectionId,
+                SubjectId = subjectId
+            }
+        };
+        var endedSession = new Session
+        {
+            Id = sessionUuid,
+            Status = SessionStatusConstants.Ended,
+            Schedule = activeSession.Schedule
+        };
+
+        _mockStudentRepository
+            .Setup(repository => repository.GetStudentByUuidAsync(studentUuid))
+            .ReturnsAsync(new Student { Id = studentUuid, SectionId = sectionId });
+        _mockSessionRepository
+            .Setup(repository => repository.GetSessionByUuidAsync(sessionUuid))
+            .ReturnsAsync(activeSession);
+        _mockAutomaticSessionEndService
+            .Setup(service => service.AutoEndIfExpiredAsync(activeSession))
+            .ReturnsAsync(endedSession);
+
+        var request = new CreateAttendanceRequest
+        {
+            StudentId = studentUuid,
+            SessionId = sessionUuid,
+            Status = "Present"
+        };
+
+        var exception = await Assert.ThrowsAsync<attendance_monitoring.Exceptions.ValidationException>(
+            () => _attendanceService.CreateAttendanceAsync(request, CreateInstructorUser("instructor-user")));
+
+        Assert.Contains("not active", exception.Message);
+        _mockAttendanceRepository.Verify(repository => repository.CreateAsync(It.IsAny<AttendanceRecord>()), Times.Never);
     }
 
     [Fact]

--- a/attendance.testproject/Services_Testing/AutomaticSessionEndBackgroundServiceTest.cs
+++ b/attendance.testproject/Services_Testing/AutomaticSessionEndBackgroundServiceTest.cs
@@ -1,0 +1,56 @@
+using attendance_monitoring.IServices;
+using attendance_monitoring.Options;
+using attendance_monitoring.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace attendance.testproject.Services_Testing;
+
+public class AutomaticSessionEndBackgroundServiceTest
+{
+    [Fact]
+    public async Task StartAsync_DoesNotScan_WhenDisabled()
+    {
+        var scopeFactory = CreateScopeFactory(new Mock<IAutomaticSessionEndService>().Object);
+        var service = new AutomaticSessionEndBackgroundService(
+            scopeFactory,
+            Options.Create(new SessionAutoEndOptions { Enabled = false }),
+            NullLogger<AutomaticSessionEndBackgroundService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        await service.StopAsync(CancellationToken.None);
+
+        var automaticEndService = Mock.Get(scopeFactory.CreateScope().ServiceProvider.GetRequiredService<IAutomaticSessionEndService>());
+        automaticEndService.Verify(scan => scan.AutoEndExpiredSessionsAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task StartAsync_ScansImmediately_WhenEnabled()
+    {
+        var scanned = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var automaticEndService = new Mock<IAutomaticSessionEndService>();
+        automaticEndService
+            .Setup(service => service.AutoEndExpiredSessionsAsync())
+            .ReturnsAsync(1)
+            .Callback(() => scanned.TrySetResult());
+
+        var service = new AutomaticSessionEndBackgroundService(
+            CreateScopeFactory(automaticEndService.Object),
+            Options.Create(new SessionAutoEndOptions { Enabled = true, ScanIntervalMinutes = 1 }),
+            NullLogger<AutomaticSessionEndBackgroundService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+        await scanned.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await service.StopAsync(CancellationToken.None);
+
+        automaticEndService.Verify(scan => scan.AutoEndExpiredSessionsAsync(), Times.AtLeastOnce);
+    }
+
+    private static IServiceScopeFactory CreateScopeFactory(IAutomaticSessionEndService automaticEndService)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(automaticEndService);
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
+}

--- a/attendance.testproject/Services_Testing/AutomaticSessionEndServiceTest.cs
+++ b/attendance.testproject/Services_Testing/AutomaticSessionEndServiceTest.cs
@@ -138,6 +138,80 @@ public class AutomaticSessionEndServiceTest
         repository.Verify(repo => repo.SaveChangesAsync(), Times.Never);
     }
 
+    [Fact]
+    public async Task AutoEndExpiredSessionsAsync_CountsOnlySessionsUpdatedByThisInvocation()
+    {
+        var repository = new Mock<ISessionRepository>();
+        var service = CreateService(
+            repository,
+            localNow: new DateTime(2026, 4, 26, 11, 52, 0));
+        var sessionEndedHere = CreateSession(
+            sessionDate: new DateTime(2026, 4, 26),
+            timeIn: new TimeOnly(10, 0),
+            timeOut: new TimeOnly(11, 30));
+        var sessionEndedElsewhere = CreateSession(
+            sessionDate: new DateTime(2026, 4, 26),
+            timeIn: new TimeOnly(10, 0),
+            timeOut: new TimeOnly(11, 30));
+        var manuallyEndedSession = CreateSession(
+            sessionDate: new DateTime(2026, 4, 26),
+            timeIn: new TimeOnly(10, 0),
+            timeOut: new TimeOnly(11, 30),
+            status: SessionStatusConstants.Ended);
+        manuallyEndedSession.Id = sessionEndedElsewhere.Id;
+        manuallyEndedSession.ActualEndTime = new DateTime(2026, 4, 26, 11, 50, 0);
+        manuallyEndedSession.EndedBy = Guid.NewGuid();
+        manuallyEndedSession.Description = "Ended manually";
+
+        repository
+            .Setup(repo => repo.GetActiveSessionsForAutoEndScanAsync(new DateTime(2026, 4, 26)))
+            .ReturnsAsync([sessionEndedHere, sessionEndedElsewhere]);
+        repository
+            .Setup(repo => repo.UpdateSessionAsync(It.Is<Session>(session => session.Id == sessionEndedHere.Id)))
+            .ReturnsAsync((Session updated) => updated);
+        repository
+            .Setup(repo => repo.UpdateSessionAsync(It.Is<Session>(session => session.Id == sessionEndedElsewhere.Id)))
+            .ThrowsAsync(new DbUpdateConcurrencyException("manual end won"));
+        repository
+            .Setup(repo => repo.SaveChangesAsync())
+            .ReturnsAsync(1);
+        repository
+            .Setup(repo => repo.GetSessionByIdAsync(sessionEndedElsewhere.Id))
+            .ReturnsAsync(manuallyEndedSession);
+
+        var endedCount = await service.AutoEndExpiredSessionsAsync();
+
+        Assert.Equal(1, endedCount);
+        repository.Verify(repo => repo.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task AutoEndIfExpiredAsync_PreservesDescriptionPrefixWhenAppendingAutoEndNote()
+    {
+        var repository = new Mock<ISessionRepository>();
+        var service = CreateService(
+            repository,
+            localNow: new DateTime(2026, 4, 26, 11, 52, 0));
+        var session = CreateSession(
+            sessionDate: new DateTime(2026, 4, 26),
+            timeIn: new TimeOnly(10, 0),
+            timeOut: new TimeOnly(11, 30));
+        session.Description = $"START-{new string('A', 470)}";
+
+        repository
+            .Setup(repo => repo.UpdateSessionAsync(It.IsAny<Session>()))
+            .ReturnsAsync((Session updated) => updated);
+        repository
+            .Setup(repo => repo.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        var result = await service.AutoEndIfExpiredAsync(session);
+
+        Assert.StartsWith("START-", result.Description);
+        Assert.EndsWith("Auto-ended by system after scheduled end grace period.", result.Description);
+        Assert.True(result.Description!.Length <= 500);
+    }
+
     private static AutomaticSessionEndService CreateService(
         Mock<ISessionRepository>? repository = null,
         DateTime? localNow = null,

--- a/attendance.testproject/Services_Testing/AutomaticSessionEndServiceTest.cs
+++ b/attendance.testproject/Services_Testing/AutomaticSessionEndServiceTest.cs
@@ -1,0 +1,177 @@
+using attendance_monitoring.Classes;
+using attendance_monitoring.Constants;
+using attendance_monitoring.Extensions;
+using attendance_monitoring.IRepository;
+using attendance_monitoring.Options;
+using attendance_monitoring.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.EntityFrameworkCore;
+
+namespace attendance.testproject.Services_Testing;
+
+public class AutomaticSessionEndServiceTest
+{
+    [Fact]
+    public void CalculateAutoEndBoundary_UsesSessionDateScheduleTimeOutAndConfiguredGrace()
+    {
+        var service = CreateService();
+        var session = CreateSession(
+            sessionDate: new DateTime(2026, 4, 26),
+            timeIn: new TimeOnly(10, 0),
+            timeOut: new TimeOnly(11, 30));
+
+        var boundary = service.CalculateAutoEndBoundary(session);
+
+        Assert.Equal(new DateTime(2026, 4, 26, 11, 45, 0), boundary);
+    }
+
+    [Fact]
+    public async Task AutoEndIfExpiredAsync_LeavesActiveSessionWithinGraceActive()
+    {
+        var repository = new Mock<ISessionRepository>();
+        var service = CreateService(
+            repository,
+            localNow: new DateTime(2026, 4, 26, 11, 44, 0));
+        var session = CreateSession(
+            sessionDate: new DateTime(2026, 4, 26),
+            timeIn: new TimeOnly(10, 0),
+            timeOut: new TimeOnly(11, 30));
+
+        var result = await service.AutoEndIfExpiredAsync(session);
+
+        Assert.Equal(SessionStatusConstants.Active, result.Status);
+        Assert.Null(result.ActualEndTime);
+        repository.Verify(repo => repo.UpdateSessionAsync(It.IsAny<Session>()), Times.Never);
+        repository.Verify(repo => repo.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task AutoEndIfExpiredAsync_EndsExpiredActiveSessionAtScheduledBoundary()
+    {
+        var repository = new Mock<ISessionRepository>();
+        var service = CreateService(
+            repository,
+            localNow: new DateTime(2026, 4, 26, 11, 52, 0));
+        var session = CreateSession(
+            sessionDate: new DateTime(2026, 4, 26),
+            timeIn: new TimeOnly(10, 0),
+            timeOut: new TimeOnly(11, 30));
+
+        repository
+            .Setup(repo => repo.UpdateSessionAsync(It.IsAny<Session>()))
+            .ReturnsAsync((Session updated) => updated);
+        repository
+            .Setup(repo => repo.SaveChangesAsync())
+            .ReturnsAsync(1);
+
+        var result = await service.AutoEndIfExpiredAsync(session);
+
+        Assert.Equal(SessionStatusConstants.Ended, result.Status);
+        Assert.Equal(new DateTime(2026, 4, 26, 11, 45, 0), result.ActualEndTime);
+        Assert.Null(result.EndedBy);
+        Assert.Contains("Auto-ended by system", result.Description);
+        repository.Verify(repo => repo.UpdateSessionAsync(
+            It.Is<Session>(updated =>
+                updated.Status == SessionStatusConstants.Ended &&
+                updated.ActualEndTime == new DateTime(2026, 4, 26, 11, 45, 0) &&
+                updated.EndedBy == null)), Times.Once);
+        repository.Verify(repo => repo.SaveChangesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task AutoEndIfExpiredAsync_DoesNotUpdateAlreadyEndedSession()
+    {
+        var repository = new Mock<ISessionRepository>();
+        var service = CreateService(
+            repository,
+            localNow: new DateTime(2026, 4, 26, 11, 52, 0));
+        var session = CreateSession(
+            sessionDate: new DateTime(2026, 4, 26),
+            timeIn: new TimeOnly(10, 0),
+            timeOut: new TimeOnly(11, 30),
+            status: SessionStatusConstants.Ended);
+
+        var result = await service.AutoEndIfExpiredAsync(session);
+
+        Assert.Equal(SessionStatusConstants.Ended, result.Status);
+        repository.Verify(repo => repo.UpdateSessionAsync(It.IsAny<Session>()), Times.Never);
+        repository.Verify(repo => repo.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task AutoEndIfExpiredAsync_ToleratesConcurrencyRace()
+    {
+        var repository = new Mock<ISessionRepository>();
+        var service = CreateService(
+            repository,
+            localNow: new DateTime(2026, 4, 26, 11, 52, 0));
+        var session = CreateSession(
+            sessionDate: new DateTime(2026, 4, 26),
+            timeIn: new TimeOnly(10, 0),
+            timeOut: new TimeOnly(11, 30));
+
+        repository
+            .Setup(repo => repo.UpdateSessionAsync(It.IsAny<Session>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException("manual end won"));
+
+        var result = await service.AutoEndIfExpiredAsync(session);
+
+        Assert.Equal(SessionStatusConstants.Ended, result.Status);
+        Assert.Equal(new DateTime(2026, 4, 26, 11, 45, 0), result.ActualEndTime);
+        repository.Verify(repo => repo.UpdateSessionAsync(It.IsAny<Session>()), Times.Once);
+        repository.Verify(repo => repo.SaveChangesAsync(), Times.Never);
+    }
+
+    private static AutomaticSessionEndService CreateService(
+        Mock<ISessionRepository>? repository = null,
+        DateTime? localNow = null,
+        SessionAutoEndOptions? options = null)
+    {
+        var effectiveLocalNow = localNow ?? new DateTime(2026, 4, 26, 12, 0, 0);
+        var timeZone = TimeZoneInfo.FindSystemTimeZoneById("Asia/Manila");
+        var utcNow = TimeZoneInfo.ConvertTimeToUtc(effectiveLocalNow, timeZone);
+        var clock = new ConfiguredTimeZoneProvider(
+            new TimeZoneSettings { TimeZoneId = "Asia/Manila" },
+            new FixedTimeProvider(utcNow));
+
+        return new AutomaticSessionEndService(
+            repository?.Object ?? new Mock<ISessionRepository>().Object,
+            Options.Create(options ?? new SessionAutoEndOptions()),
+            clock,
+            NullLogger<AutomaticSessionEndService>.Instance);
+    }
+
+    private static Session CreateSession(
+        DateTime sessionDate,
+        TimeOnly timeIn,
+        TimeOnly timeOut,
+        string status = SessionStatusConstants.Active)
+    {
+        return new Session
+        {
+            Id = Guid.NewGuid(),
+            ScheduleId = Guid.NewGuid(),
+            Status = status,
+            SessionDate = sessionDate.Date,
+            ActualStartTime = sessionDate.Date.Add(timeIn.ToTimeSpan()),
+            RowVersion = [1, 2, 3, 4],
+            Schedule = new Schedules
+            {
+                Id = Guid.NewGuid(),
+                DayOfWeek = sessionDate.DayOfWeek.ToString(),
+                TimeIn = timeIn,
+                TimeOut = timeOut,
+                SubjectId = Guid.NewGuid(),
+                ClassroomId = Guid.NewGuid(),
+                SectionId = Guid.NewGuid(),
+                InstructorId = Guid.NewGuid()
+            }
+        };
+    }
+
+    private sealed class FixedTimeProvider(DateTime utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => new DateTimeOffset(utcNow, TimeSpan.Zero);
+    }
+}

--- a/attendance.testproject/Services_Testing/AutomaticSessionEndServiceTest.cs
+++ b/attendance.testproject/Services_Testing/AutomaticSessionEndServiceTest.cs
@@ -100,7 +100,7 @@ public class AutomaticSessionEndServiceTest
     }
 
     [Fact]
-    public async Task AutoEndIfExpiredAsync_ToleratesConcurrencyRace()
+    public async Task AutoEndIfExpiredAsync_ReloadsCurrentStateAfterConcurrencyRace()
     {
         var repository = new Mock<ISessionRepository>();
         var service = CreateService(
@@ -110,16 +110,31 @@ public class AutomaticSessionEndServiceTest
             sessionDate: new DateTime(2026, 4, 26),
             timeIn: new TimeOnly(10, 0),
             timeOut: new TimeOnly(11, 30));
+        var manuallyEndedSession = CreateSession(
+            sessionDate: new DateTime(2026, 4, 26),
+            timeIn: new TimeOnly(10, 0),
+            timeOut: new TimeOnly(11, 30),
+            status: SessionStatusConstants.Ended);
+        manuallyEndedSession.Id = session.Id;
+        manuallyEndedSession.ActualEndTime = new DateTime(2026, 4, 26, 11, 50, 0);
+        manuallyEndedSession.EndedBy = Guid.NewGuid();
+        manuallyEndedSession.Description = "Ended manually";
 
         repository
             .Setup(repo => repo.UpdateSessionAsync(It.IsAny<Session>()))
             .ThrowsAsync(new DbUpdateConcurrencyException("manual end won"));
+        repository
+            .Setup(repo => repo.GetSessionByIdAsync(session.Id))
+            .ReturnsAsync(manuallyEndedSession);
 
         var result = await service.AutoEndIfExpiredAsync(session);
 
         Assert.Equal(SessionStatusConstants.Ended, result.Status);
-        Assert.Equal(new DateTime(2026, 4, 26, 11, 45, 0), result.ActualEndTime);
+        Assert.Equal(new DateTime(2026, 4, 26, 11, 50, 0), result.ActualEndTime);
+        Assert.Equal(manuallyEndedSession.EndedBy, result.EndedBy);
+        Assert.Equal("Ended manually", result.Description);
         repository.Verify(repo => repo.UpdateSessionAsync(It.IsAny<Session>()), Times.Once);
+        repository.Verify(repo => repo.GetSessionByIdAsync(session.Id), Times.Once);
         repository.Verify(repo => repo.SaveChangesAsync(), Times.Never);
     }
 

--- a/attendance.testproject/Services_Testing/FingerprintServiceTest.cs
+++ b/attendance.testproject/Services_Testing/FingerprintServiceTest.cs
@@ -28,6 +28,7 @@ public class FingerprintServiceTest
     private readonly Mock<IStudentEnrollmentRepository> _mockStudentEnrollmentRepository;
     private readonly Mock<IAttendanceRepository> _mockAttendanceRepository;
     private readonly Mock<IAttendanceService> _mockAttendanceService;
+    private readonly Mock<IAutomaticSessionEndService> _mockAutomaticSessionEndService;
     private readonly Mock<INotificationService> _mockNotificationService;
     private readonly Mock<ILogger<FingerprintService>> _mockLogger;
     private readonly Mock<IDbContextTransaction> _mockTransaction;
@@ -46,6 +47,7 @@ public class FingerprintServiceTest
         _mockStudentEnrollmentRepository = new Mock<IStudentEnrollmentRepository>();
         _mockAttendanceRepository = new Mock<IAttendanceRepository>();
         _mockAttendanceService = new Mock<IAttendanceService>();
+        _mockAutomaticSessionEndService = new Mock<IAutomaticSessionEndService>();
         _mockNotificationService = new Mock<INotificationService>();
         _mockLogger = new Mock<ILogger<FingerprintService>>();
         _mockTransaction = new Mock<IDbContextTransaction>();
@@ -75,6 +77,9 @@ public class FingerprintServiceTest
 
                 return "Late";
             });
+        _mockAutomaticSessionEndService
+            .Setup(service => service.AutoEndIfExpiredAsync(It.IsAny<Session>()))
+            .ReturnsAsync((Session session) => session);
 
         var contextOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
@@ -471,6 +476,96 @@ public class FingerprintServiceTest
         Assert.False(response.Success);
         Assert.Equal("Student is not enrolled in this session", response.Message);
 
+        _mockAttendanceRepository.Verify(
+            repository => repository.CreateAsync(It.IsAny<AttendanceRecord>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ScanFingerprintBySensorAsync_WithAutoEndedRequestedSession_ReturnsSessionNotActive()
+    {
+        var service = CreateService();
+        var device = new FingerprintDevice
+        {
+            Id = Guid.NewGuid(),
+            DeviceIdentifier = "esp32-attendance-01",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        var student = new Student
+        {
+            Id = Guid.NewGuid(),
+            UserId = "user-1",
+            Firstname = "John",
+            Lastname = "Doe",
+            SectionId = Guid.NewGuid(),
+            IsDeleted = false
+        };
+        var session = new Session
+        {
+            Id = Guid.NewGuid(),
+            ScheduleId = Guid.NewGuid(),
+            SessionDate = DateTime.Now.Date,
+            Status = SessionStatusConstants.Active,
+            ActualStartTime = DateTime.Now.AddMinutes(-5),
+            Schedule = new Schedules
+            {
+                Id = Guid.NewGuid(),
+                SectionId = student.SectionId,
+                SubjectId = Guid.NewGuid(),
+                Section = new Section { Id = student.SectionId, Name = "BSCS 3A" },
+                Subject = new Subject { Id = Guid.NewGuid(), Name = "Software Engineering" },
+                Instructor = new Instructor { Id = Guid.NewGuid(), Firstname = "Ada", Lastname = "Lovelace", UserId = "inst-1" }
+            }
+        };
+        var endedSession = new Session
+        {
+            Id = session.Id,
+            ScheduleId = session.ScheduleId,
+            SessionDate = session.SessionDate,
+            Status = SessionStatusConstants.Ended,
+            Schedule = session.Schedule
+        };
+
+        _context.FingerprintDevices.Add(device);
+        await _context.SaveChangesAsync();
+
+        _mockFingerprintRepository
+            .Setup(repository => repository.FindFingerprintByDeviceAndSensorIdAsync(device.DeviceIdentifier, 5))
+            .ReturnsAsync(new Fingerprint
+            {
+                Id = Guid.NewGuid(),
+                UserId = student.UserId,
+                DeviceId = device.DeviceIdentifier,
+                SensorFingerprintId = 5,
+                TemplateData = "ciphertext"
+            });
+        _mockStudentRepository
+            .Setup(repository => repository.GetStudentByUserIdAsync(student.UserId))
+            .ReturnsAsync(student);
+        _mockSessionRepository
+            .Setup(repository => repository.GetSessionByUuidAsync(session.Id))
+            .ReturnsAsync(session);
+        _mockSessionRepository
+            .Setup(repository => repository.GetSessionByIdAsync(session.Id))
+            .ReturnsAsync(session);
+        _mockAutomaticSessionEndService
+            .Setup(service => service.AutoEndIfExpiredAsync(session))
+            .ReturnsAsync(endedSession);
+
+        var response = await service.ScanFingerprintBySensorAsync(
+            new ScanFingerprintBySensorRequest
+            {
+                DeviceId = device.DeviceIdentifier,
+                SensorFingerprintId = 5,
+                Confidence = 90,
+                SessionId = session.Id
+            },
+            "device-secret");
+
+        Assert.False(response.Success);
+        Assert.Equal("Session is not active", response.Message);
         _mockAttendanceRepository.Verify(
             repository => repository.CreateAsync(It.IsAny<AttendanceRecord>()),
             Times.Never);
@@ -938,7 +1033,8 @@ public class FingerprintServiceTest
             configurationOverride ?? _configuration,
             _dataProtectionProvider,
             _timeZoneProvider,
-            _mockLogger.Object);
+            _mockLogger.Object,
+            _mockAutomaticSessionEndService.Object);
     }
 
     private static ClaimsPrincipal CreatePrivilegedPrincipal()

--- a/attendance.testproject/Services_Testing/QrCodeServiceTest.cs
+++ b/attendance.testproject/Services_Testing/QrCodeServiceTest.cs
@@ -124,6 +124,32 @@ public class QrCodeServiceTest
     }
 
     [Fact]
+    public async Task ValidateSessionExistsOrThrowAsync_RejectsSessionAutoEndedDuringRequest()
+    {
+        var sessionId = Guid.NewGuid();
+        var activeSession = new Session { Id = sessionId, Status = SessionStatusConstants.Active };
+        var endedSession = new Session { Id = sessionId, Status = SessionStatusConstants.Ended };
+        var sessionRepository = new Mock<ISessionRepository>();
+        var automaticEndService = new Mock<IAutomaticSessionEndService>();
+
+        sessionRepository
+            .Setup(repository => repository.GetSessionByIdAsync(sessionId))
+            .ReturnsAsync(activeSession);
+        automaticEndService
+            .Setup(service => service.AutoEndIfExpiredAsync(activeSession))
+            .ReturnsAsync(endedSession);
+
+        var authorizationService = CreateAuthorizationService(
+            sessionRepository.Object,
+            automaticSessionEndService: automaticEndService.Object);
+
+        var exception = await Assert.ThrowsAsync<attendance_monitoring.Exceptions.ValidationException>(
+            () => authorizationService.ValidateSessionExistsOrThrowAsync(sessionId));
+
+        Assert.Contains("ended", exception.Message);
+    }
+
+    [Fact]
     public async Task ExtendQrCodeExpirationByUuidAsync_DelegatesToWriteService()
     {
         var originalExpiration = DateTime.UtcNow.AddMinutes(5);
@@ -251,7 +277,10 @@ public class QrCodeServiceTest
             sessionRepository,
             NullLogger<QrCodeGenerationService>.Instance);
 
-    private static QrCodeAuthorizationService CreateAuthorizationService(ISessionRepository sessionRepository, bool adminOnly = false)
+    private static QrCodeAuthorizationService CreateAuthorizationService(
+        ISessionRepository sessionRepository,
+        bool adminOnly = false,
+        IAutomaticSessionEndService? automaticSessionEndService = null)
     {
         var userContextService = new Mock<IUserContextService>();
         userContextService
@@ -268,7 +297,8 @@ public class QrCodeServiceTest
             sessionRepository,
             Mock.Of<IStudentEnrollmentService>(),
             userContextService.Object,
-            NullLogger<QrCodeAuthorizationService>.Instance);
+            NullLogger<QrCodeAuthorizationService>.Instance,
+            automaticSessionEndService);
     }
 
     private static Mock<IQrCodeRepository> CreateAuthorizedRepository(bool adminOnly = false)

--- a/attendance.testproject/Services_Testing/SessionServiceTest.cs
+++ b/attendance.testproject/Services_Testing/SessionServiceTest.cs
@@ -32,6 +32,7 @@ public class SessionServiceTest
     private readonly Mock<INotificationService> _mockNotificationService;
     private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor;
     private readonly Mock<ILogger<SessionService>> _mockLogger;
+    private readonly Mock<IAutomaticSessionEndService> _mockAutomaticSessionEndService;
     private readonly ConfiguredTimeZoneProvider _timeZoneProvider;
     private readonly Mock<UserManager<IdentityUser>> _mockUserManager;
     private readonly UserContextService _userContextService;
@@ -49,6 +50,7 @@ public class SessionServiceTest
         _mockNotificationService = new Mock<INotificationService>();
         _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
         _mockLogger = new Mock<ILogger<SessionService>>();
+        _mockAutomaticSessionEndService = new Mock<IAutomaticSessionEndService>();
 
         // Mock UserManager for UserContextService
         var mockUserStore = new Mock<IUserStore<IdentityUser>>();
@@ -85,6 +87,9 @@ public class SessionServiceTest
         };
 
         _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(_httpContext);
+        _mockAutomaticSessionEndService
+            .Setup(service => service.AutoEndIfExpiredAsync(It.IsAny<Session>()))
+            .ReturnsAsync((Session session) => session);
 
         _timeZoneProvider = new ConfiguredTimeZoneProvider(
             new TimeZoneSettings { TimeZoneId = TimeZoneInfo.Local.Id });
@@ -99,7 +104,8 @@ public class SessionServiceTest
             _userContextService,
             _mockHttpContextAccessor.Object,
             _timeZoneProvider,
-            _mockLogger.Object
+            _mockLogger.Object,
+            _mockAutomaticSessionEndService.Object
         );
     }
 
@@ -298,6 +304,35 @@ public class SessionServiceTest
         Assert.NotNull(result);
         Assert.Equal(2, result.Count());
         Assert.All(result, s => Assert.Equal(SessionStatusConstants.Active, s.Status));
+    }
+
+    [Fact]
+    public async Task GetSessionsByStatusAsync_ReturnsExpiredActiveSessionsWhenRequestingEndedStatus()
+    {
+        var status = SessionStatusConstants.Ended;
+        var endedSession = CreateTestSession(status: SessionStatusConstants.Ended);
+        var expiredActiveSession = CreateTestSession(status: SessionStatusConstants.Active);
+        var normalizedExpiredSession = CreateTestSession(
+            id: expiredActiveSession.Id,
+            scheduleId: expiredActiveSession.ScheduleId,
+            status: SessionStatusConstants.Ended,
+            sessionDate: expiredActiveSession.SessionDate);
+
+        _mockSessionRepository
+            .Setup(r => r.GetSessionsByStatusAsync(status))
+            .ReturnsAsync([endedSession]);
+        _mockSessionRepository
+            .Setup(r => r.GetAllSessionsAsync())
+            .ReturnsAsync([endedSession, expiredActiveSession]);
+        _mockAutomaticSessionEndService
+            .Setup(service => service.AutoEndIfExpiredAsync(It.Is<Session>(session => session.Id == expiredActiveSession.Id)))
+            .ReturnsAsync(normalizedExpiredSession);
+
+        var result = (await _sessionService.GetSessionsByStatusAsync(status)).ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, session => session.Id == endedSession.Id);
+        Assert.Contains(result, session => session.Id == expiredActiveSession.Id);
     }
 
     #endregion

--- a/attendance.testproject/Services_Testing/SessionServiceTest.cs
+++ b/attendance.testproject/Services_Testing/SessionServiceTest.cs
@@ -319,10 +319,11 @@ public class SessionServiceTest
             sessionDate: expiredActiveSession.SessionDate);
 
         _mockSessionRepository
-            .Setup(r => r.GetSessionsByStatusAsync(status))
-            .ReturnsAsync([endedSession]);
-        _mockSessionRepository
-            .Setup(r => r.GetAllSessionsAsync())
+            .Setup(r => r.GetSessionsByStatusesAsync(
+                It.Is<IReadOnlyCollection<string>>(statuses =>
+                    statuses.Contains(SessionStatusConstants.Active) &&
+                    statuses.Contains(SessionStatusConstants.Ended) &&
+                    statuses.Count == 2)))
             .ReturnsAsync([endedSession, expiredActiveSession]);
         _mockAutomaticSessionEndService
             .Setup(service => service.AutoEndIfExpiredAsync(It.Is<Session>(session => session.Id == expiredActiveSession.Id)))
@@ -333,6 +334,7 @@ public class SessionServiceTest
         Assert.Equal(2, result.Count);
         Assert.Contains(result, session => session.Id == endedSession.Id);
         Assert.Contains(result, session => session.Id == expiredActiveSession.Id);
+        _mockSessionRepository.Verify(r => r.GetAllSessionsAsync(), Times.Never);
     }
 
     #endregion

--- a/attendance_monitoring/.env.example
+++ b/attendance_monitoring/.env.example
@@ -8,3 +8,8 @@ CookieSettings__AccessTokenExpirationMinutes=15
 CookieSettings__RefreshTokenExpirationDays=7
 # CORS Settings - Separate multiple origins with semicolons (;)
 CorsSettings__AllowedOrigins=http://localhost:5173;http://localhost:3000
+# Session Auto-End Settings
+# Automatically end active sessions after scheduled end time + grace period
+SessionAutoEnd__Enabled=true
+SessionAutoEnd__GraceMinutes=15
+SessionAutoEnd__ScanIntervalMinutes=5

--- a/attendance_monitoring/Extensions/ServiceCollectionExtensions/DependencyInjectionExtensions.cs
+++ b/attendance_monitoring/Extensions/ServiceCollectionExtensions/DependencyInjectionExtensions.cs
@@ -47,6 +47,9 @@ public static class DependencyInjectionExtensions
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddApplicationServices(this IServiceCollection services)
     {
+        services.AddOptions<SessionAutoEndOptions>()
+            .BindConfiguration(SessionAutoEndOptions.SectionName);
+
         // Register ConfiguredTimeZoneProvider with fallback to system local time
         services.AddSingleton<ConfiguredTimeZoneProvider>(sp =>
         {
@@ -97,6 +100,7 @@ public static class DependencyInjectionExtensions
         services.AddScoped<ITokenValidationService, TokenValidationService>();
         services.AddScoped<ICookieOptionsService, CookieOptionsService>();
         services.AddScoped<IStudentEnrollmentService, StudentEnrollmentService>();
+        services.AddScoped<IAutomaticSessionEndService, AutomaticSessionEndService>();
         services.AddScoped<ISessionService, SessionService>();
         services.AddScoped<IAttendanceService, AttendanceService>();
         services.AddScoped<IReportsService, ReportsService>();
@@ -121,6 +125,7 @@ public static class DependencyInjectionExtensions
     {
         services.AddHostedService<BlacklistedTokenCleanupService>();
         services.AddHostedService<RoleInitializationBackgroundService>();
+        services.AddHostedService<AutomaticSessionEndBackgroundService>();
         
         // Orphaned user cleanup and monitoring service
         services.AddSingleton<OrphanedUserCleanupService>();

--- a/attendance_monitoring/Extensions/ServiceCollectionExtensions/DependencyInjectionExtensions.cs
+++ b/attendance_monitoring/Extensions/ServiceCollectionExtensions/DependencyInjectionExtensions.cs
@@ -47,9 +47,6 @@ public static class DependencyInjectionExtensions
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddApplicationServices(this IServiceCollection services)
     {
-        services.AddOptions<SessionAutoEndOptions>()
-            .BindConfiguration(SessionAutoEndOptions.SectionName);
-
         // Register ConfiguredTimeZoneProvider with fallback to system local time
         services.AddSingleton<ConfiguredTimeZoneProvider>(sp =>
         {

--- a/attendance_monitoring/IRepository/ISessionRepository.cs
+++ b/attendance_monitoring/IRepository/ISessionRepository.cs
@@ -86,6 +86,13 @@ public interface ISessionRepository : ISaveableRepository
     Task<IEnumerable<Session>> GetActiveSessionsByInstructorIdAsync(Guid instructorId);
 
     /// <summary>
+    /// Retrieves active sessions on or before a local date for automatic ending evaluation.
+    /// </summary>
+    /// <param name="currentLocalDate">The current local date used to narrow scan candidates</param>
+    /// <returns>Collection of active sessions that are possible auto-end candidates</returns>
+    Task<IEnumerable<Session>> GetActiveSessionsForAutoEndScanAsync(DateTime currentLocalDate);
+
+    /// <summary>
     /// Retrieves all sessions for a specific instructor (all statuses).
     /// </summary>
     /// <param name="instructorId">The instructor ID</param>

--- a/attendance_monitoring/IRepository/ISessionRepository.cs
+++ b/attendance_monitoring/IRepository/ISessionRepository.cs
@@ -50,6 +50,13 @@ public interface ISessionRepository : ISaveableRepository
     Task<IEnumerable<Session>> GetSessionsByStatusAsync(string status);
 
     /// <summary>
+    /// Retrieves sessions matching any of the specified statuses.
+    /// </summary>
+    /// <param name="statuses">Session statuses to include</param>
+    /// <returns>Collection of sessions with any matching status</returns>
+    Task<IEnumerable<Session>> GetSessionsByStatusesAsync(IReadOnlyCollection<string> statuses);
+
+    /// <summary>
     /// Retrieves sessions for a specific date.
     /// </summary>
     /// <param name="date">The session date</param>

--- a/attendance_monitoring/IServices/IAutomaticSessionEndService.cs
+++ b/attendance_monitoring/IServices/IAutomaticSessionEndService.cs
@@ -1,0 +1,14 @@
+using attendance_monitoring.Classes;
+
+namespace attendance_monitoring.IServices;
+
+public interface IAutomaticSessionEndService
+{
+    DateTime CalculateAutoEndBoundary(Session session);
+
+    bool IsPastAutoEndBoundary(Session session);
+
+    Task<Session> AutoEndIfExpiredAsync(Session session);
+
+    Task<int> AutoEndExpiredSessionsAsync();
+}

--- a/attendance_monitoring/Options/SessionAutoEndOptions.cs
+++ b/attendance_monitoring/Options/SessionAutoEndOptions.cs
@@ -1,0 +1,16 @@
+namespace attendance_monitoring.Options;
+
+public sealed class SessionAutoEndOptions
+{
+    public const string SectionName = "SessionAutoEnd";
+
+    public bool Enabled { get; set; } = true;
+
+    public int GraceMinutes { get; set; } = 15;
+
+    public int ScanIntervalMinutes { get; set; } = 5;
+
+    public TimeSpan GracePeriod => TimeSpan.FromMinutes(Math.Max(0, GraceMinutes));
+
+    public TimeSpan ScanInterval => TimeSpan.FromMinutes(Math.Max(1, ScanIntervalMinutes));
+}

--- a/attendance_monitoring/Program.cs
+++ b/attendance_monitoring/Program.cs
@@ -19,6 +19,7 @@ builder.Services.AddAuthorizationPolicies();
 
 // Bulk data
 builder.Services.Configure<BulkDataOptions>(builder.Configuration.GetSection(BulkDataOptions.SectionName));
+builder.Services.Configure<SessionAutoEndOptions>(builder.Configuration.GetSection(SessionAutoEndOptions.SectionName));
 
 // API Documentation
 builder.Services.AddApiDocumentation();

--- a/attendance_monitoring/Repositories/SessionRepository.cs
+++ b/attendance_monitoring/Repositories/SessionRepository.cs
@@ -283,6 +283,34 @@ public class SessionRepository(ApplicationDbContext context) : ISessionRepositor
     }
 
     /// <summary>
+    /// Retrieves active sessions on or before the current local date for automatic ending evaluation.
+    /// </summary>
+    public async Task<IEnumerable<Session>> GetActiveSessionsForAutoEndScanAsync(DateTime currentLocalDate)
+    {
+        var dateOnly = currentLocalDate.Date;
+
+        return await context.Sessions
+            .AsNoTracking()
+            .AsSplitQuery()
+            .Include(s => s.Schedule)
+                .ThenInclude(sch => sch.Subject)
+            .Include(s => s.Schedule)
+                .ThenInclude(sch => sch.Section)
+            .Include(s => s.Schedule)
+                .ThenInclude(sch => sch.Classroom)
+            .Include(s => s.Schedule)
+                .ThenInclude(sch => sch.Instructor)
+            .Include(s => s.ActualRoom)
+            .Include(s => s.InstructorWhoStarted)
+            .Include(s => s.InstructorWhoEnded)
+            .Where(s => s.Status == SessionStatusConstants.Active && s.SessionDate.Date <= dateOnly)
+            .OrderBy(s => s.SessionDate)
+            .ThenBy(s => s.Schedule.TimeOut)
+            .ToListAsync()
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Retrieves all sessions for a specific instructor (all statuses).
     /// </summary>
     public async Task<IEnumerable<Session>> GetSessionsByInstructorIdAsync(Guid instructorId)

--- a/attendance_monitoring/Repositories/SessionRepository.cs
+++ b/attendance_monitoring/Repositories/SessionRepository.cs
@@ -159,6 +159,31 @@ public class SessionRepository(ApplicationDbContext context) : ISessionRepositor
     }
 
     /// <summary>
+    /// Retrieves sessions by any matching status.
+    /// </summary>
+    public async Task<IEnumerable<Session>> GetSessionsByStatusesAsync(IReadOnlyCollection<string> statuses)
+    {
+        return await context.Sessions
+            .AsNoTracking()
+            .AsSplitQuery()
+            .Include(s => s.Schedule)
+                .ThenInclude(sch => sch.Subject)
+            .Include(s => s.Schedule)
+                .ThenInclude(sch => sch.Section)
+            .Include(s => s.Schedule)
+                .ThenInclude(sch => sch.Classroom)
+            .Include(s => s.Schedule)
+                .ThenInclude(sch => sch.Instructor)
+            .Include(s => s.ActualRoom)
+            .Include(s => s.InstructorWhoStarted)
+            .Include(s => s.InstructorWhoEnded)
+            .Where(s => statuses.Contains(s.Status))
+            .OrderByDescending(s => s.SessionDate)
+            .ToListAsync()
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Retrieves sessions for a specific date.
     /// </summary>
     public async Task<IEnumerable<Session>> GetSessionsByDateAsync(DateTime date)

--- a/attendance_monitoring/Services/AttendanceService.cs
+++ b/attendance_monitoring/Services/AttendanceService.cs
@@ -23,7 +23,8 @@ public class AttendanceService(
     IStudentEnrollmentRepository studentEnrollmentRepository,
     IUserContextService userContextService,
     ILogger<AttendanceService> logger,
-    ConfiguredTimeZoneProvider clock) : IAttendanceService
+    ConfiguredTimeZoneProvider clock,
+    IAutomaticSessionEndService? automaticSessionEndService = null) : IAttendanceService
 {
     #region Create Operations
 
@@ -679,6 +680,10 @@ public class AttendanceService(
 
         // Verify session exists and is active
         var session = await sessionRepository.GetSessionByIdAsync(sessionId).ConfigureAwait(false);
+        if (session != null && automaticSessionEndService != null)
+        {
+            session = await automaticSessionEndService.AutoEndIfExpiredAsync(session).ConfigureAwait(false);
+        }
         if (session == null || session.Status != SessionStatusConstants.Active)
         {
             return false;
@@ -750,6 +755,17 @@ public class AttendanceService(
         if (session == null)
         {
             throw new EntityNotFoundException<Guid>("Session", sessionId.Value);
+        }
+
+        var wasActive = session.Status == SessionStatusConstants.Active;
+        if (automaticSessionEndService != null)
+        {
+            session = await automaticSessionEndService.AutoEndIfExpiredAsync(session).ConfigureAwait(false);
+        }
+
+        if (wasActive && session.Status != SessionStatusConstants.Active)
+        {
+            throw new ValidationException("Cannot submit attendance for a session that is not active.");
         }
 
         return session;

--- a/attendance_monitoring/Services/AutomaticSessionEndBackgroundService.cs
+++ b/attendance_monitoring/Services/AutomaticSessionEndBackgroundService.cs
@@ -1,0 +1,46 @@
+using attendance_monitoring.IServices;
+using attendance_monitoring.Options;
+using Microsoft.Extensions.Options;
+
+namespace attendance_monitoring.Services;
+
+public sealed class AutomaticSessionEndBackgroundService(
+    IServiceScopeFactory scopeFactory,
+    IOptions<SessionAutoEndOptions> options,
+    ILogger<AutomaticSessionEndBackgroundService> logger) : BackgroundService
+{
+    private readonly SessionAutoEndOptions _options = options.Value;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.Enabled)
+        {
+            logger.LogInformation("Automatic session ending is disabled.");
+            return;
+        }
+
+        logger.LogInformation(
+            "Automatic session ending started with scan interval {ScanInterval}.",
+            _options.ScanInterval);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                using var scope = scopeFactory.CreateScope();
+                var service = scope.ServiceProvider.GetRequiredService<IAutomaticSessionEndService>();
+                await service.AutoEndExpiredSessionsAsync().ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Automatic session ending scan failed.");
+            }
+
+            await Task.Delay(_options.ScanInterval, stoppingToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/attendance_monitoring/Services/AutomaticSessionEndService.cs
+++ b/attendance_monitoring/Services/AutomaticSessionEndService.cs
@@ -1,0 +1,133 @@
+using attendance_monitoring.Classes;
+using attendance_monitoring.Constants;
+using attendance_monitoring.Extensions;
+using attendance_monitoring.IRepository;
+using attendance_monitoring.IServices;
+using attendance_monitoring.Options;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace attendance_monitoring.Services;
+
+public sealed class AutomaticSessionEndService(
+    ISessionRepository sessionRepository,
+    IOptions<SessionAutoEndOptions> options,
+    ConfiguredTimeZoneProvider clock,
+    ILogger<AutomaticSessionEndService> logger) : IAutomaticSessionEndService
+{
+    private const string AutoEndNote = "Auto-ended by system after scheduled end grace period.";
+    private readonly SessionAutoEndOptions _options = options.Value;
+
+    public DateTime CalculateAutoEndBoundary(Session session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        if (session.Schedule == null)
+        {
+            throw new InvalidOperationException("Session schedule information is required to calculate auto-end boundary.");
+        }
+
+        return session.SessionDate.Date
+            .Add(session.Schedule.TimeOut.ToTimeSpan())
+            .Add(_options.GracePeriod);
+    }
+
+    public bool IsPastAutoEndBoundary(Session session)
+    {
+        if (!_options.Enabled || session.Status != SessionStatusConstants.Active)
+        {
+            return false;
+        }
+
+        return clock.GetLocalNow() >= CalculateAutoEndBoundary(session);
+    }
+
+    public async Task<Session> AutoEndIfExpiredAsync(Session session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        if (!IsPastAutoEndBoundary(session))
+        {
+            return session;
+        }
+
+        var boundary = CalculateAutoEndBoundary(session);
+        var processedAt = clock.GetLocalNow();
+
+        session.Status = SessionStatusConstants.Ended;
+        session.ActualEndTime = boundary;
+        session.EndedBy = null;
+        session.Description = AppendAutoEndNote(session.Description);
+
+        try
+        {
+            await sessionRepository.UpdateSessionAsync(session).ConfigureAwait(false);
+            await sessionRepository.SaveChangesAsync().ConfigureAwait(false);
+
+            logger.LogInformation(
+                "Auto-ended session {SessionId} at boundary {AutoEndBoundary:o}; processed at {ProcessedAt:o}",
+                session.Id,
+                boundary,
+                processedAt);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            logger.LogInformation(
+                ex,
+                "Skipped auto-ending session {SessionId} because another update won the race",
+                session.Id);
+        }
+
+        return session;
+    }
+
+    public async Task<int> AutoEndExpiredSessionsAsync()
+    {
+        if (!_options.Enabled)
+        {
+            logger.LogDebug("Session auto-end scan skipped because auto-end is disabled.");
+            return 0;
+        }
+
+        var now = clock.GetLocalNow();
+        var candidates = await sessionRepository
+            .GetActiveSessionsForAutoEndScanAsync(now.Date)
+            .ConfigureAwait(false);
+
+        var endedCount = 0;
+        foreach (var session in candidates)
+        {
+            if (!IsPastAutoEndBoundary(session))
+            {
+                continue;
+            }
+
+            await AutoEndIfExpiredAsync(session).ConfigureAwait(false);
+            endedCount++;
+        }
+
+        logger.LogInformation(
+            "Session auto-end scan completed. Auto-ended {EndedCount} session(s).",
+            endedCount);
+
+        return endedCount;
+    }
+
+    private static string AppendAutoEndNote(string? existingDescription)
+    {
+        if (string.IsNullOrWhiteSpace(existingDescription))
+        {
+            return AutoEndNote;
+        }
+
+        if (existingDescription.Contains(AutoEndNote, StringComparison.Ordinal))
+        {
+            return existingDescription;
+        }
+
+        var combined = $"{existingDescription}\n\n{AutoEndNote}";
+        return combined.Length <= 500
+            ? combined
+            : combined[^500..];
+    }
+}

--- a/attendance_monitoring/Services/AutomaticSessionEndService.cs
+++ b/attendance_monitoring/Services/AutomaticSessionEndService.cs
@@ -53,6 +53,10 @@ public sealed class AutomaticSessionEndService(
 
         var boundary = CalculateAutoEndBoundary(session);
         var processedAt = clock.GetLocalNow();
+        var originalStatus = session.Status;
+        var originalActualEndTime = session.ActualEndTime;
+        var originalEndedBy = session.EndedBy;
+        var originalDescription = session.Description;
 
         session.Status = SessionStatusConstants.Ended;
         session.ActualEndTime = boundary;
@@ -74,8 +78,19 @@ public sealed class AutomaticSessionEndService(
         {
             logger.LogInformation(
                 ex,
-                "Skipped auto-ending session {SessionId} because another update won the race",
+                "Reloading session {SessionId} because another update won the auto-end race",
                 session.Id);
+
+            var currentSession = await sessionRepository.GetSessionByIdAsync(session.Id).ConfigureAwait(false);
+            if (currentSession != null)
+            {
+                return currentSession;
+            }
+
+            session.Status = originalStatus;
+            session.ActualEndTime = originalActualEndTime;
+            session.EndedBy = originalEndedBy;
+            session.Description = originalDescription;
         }
 
         return session;

--- a/attendance_monitoring/Services/AutomaticSessionEndService.cs
+++ b/attendance_monitoring/Services/AutomaticSessionEndService.cs
@@ -44,11 +44,47 @@ public sealed class AutomaticSessionEndService(
 
     public async Task<Session> AutoEndIfExpiredAsync(Session session)
     {
+        var (_, normalizedSession) = await TryAutoEndIfExpiredAsync(session).ConfigureAwait(false);
+        return normalizedSession;
+    }
+
+    public async Task<int> AutoEndExpiredSessionsAsync()
+    {
+        if (!_options.Enabled)
+        {
+            logger.LogDebug("Session auto-end scan skipped because auto-end is disabled.");
+            return 0;
+        }
+
+        var now = clock.GetLocalNow();
+        var candidates = await sessionRepository
+            .GetActiveSessionsForAutoEndScanAsync(now.Date)
+            .ConfigureAwait(false);
+
+        var endedCount = 0;
+        foreach (var session in candidates)
+        {
+            var (updatedHere, _) = await TryAutoEndIfExpiredAsync(session).ConfigureAwait(false);
+            if (updatedHere)
+            {
+                endedCount++;
+            }
+        }
+
+        logger.LogInformation(
+            "Session auto-end scan completed. Auto-ended {EndedCount} session(s).",
+            endedCount);
+
+        return endedCount;
+    }
+
+    private async Task<(bool UpdatedHere, Session Session)> TryAutoEndIfExpiredAsync(Session session)
+    {
         ArgumentNullException.ThrowIfNull(session);
 
         if (!IsPastAutoEndBoundary(session))
         {
-            return session;
+            return (false, session);
         }
 
         var boundary = CalculateAutoEndBoundary(session);
@@ -73,6 +109,7 @@ public sealed class AutomaticSessionEndService(
                 session.Id,
                 boundary,
                 processedAt);
+            return (true, session);
         }
         catch (DbUpdateConcurrencyException ex)
         {
@@ -84,7 +121,7 @@ public sealed class AutomaticSessionEndService(
             var currentSession = await sessionRepository.GetSessionByIdAsync(session.Id).ConfigureAwait(false);
             if (currentSession != null)
             {
-                return currentSession;
+                return (false, currentSession);
             }
 
             session.Status = originalStatus;
@@ -93,39 +130,7 @@ public sealed class AutomaticSessionEndService(
             session.Description = originalDescription;
         }
 
-        return session;
-    }
-
-    public async Task<int> AutoEndExpiredSessionsAsync()
-    {
-        if (!_options.Enabled)
-        {
-            logger.LogDebug("Session auto-end scan skipped because auto-end is disabled.");
-            return 0;
-        }
-
-        var now = clock.GetLocalNow();
-        var candidates = await sessionRepository
-            .GetActiveSessionsForAutoEndScanAsync(now.Date)
-            .ConfigureAwait(false);
-
-        var endedCount = 0;
-        foreach (var session in candidates)
-        {
-            if (!IsPastAutoEndBoundary(session))
-            {
-                continue;
-            }
-
-            await AutoEndIfExpiredAsync(session).ConfigureAwait(false);
-            endedCount++;
-        }
-
-        logger.LogInformation(
-            "Session auto-end scan completed. Auto-ended {EndedCount} session(s).",
-            endedCount);
-
-        return endedCount;
+        return (false, session);
     }
 
     private static string AppendAutoEndNote(string? existingDescription)
@@ -140,9 +145,12 @@ public sealed class AutomaticSessionEndService(
             return existingDescription;
         }
 
-        var combined = $"{existingDescription}\n\n{AutoEndNote}";
-        return combined.Length <= 500
-            ? combined
-            : combined[^500..];
+        const string separator = "\n\n";
+        var maxExistingDescriptionLength = Math.Max(0, 500 - separator.Length - AutoEndNote.Length);
+        var trimmedDescription = existingDescription.Length <= maxExistingDescriptionLength
+            ? existingDescription
+            : existingDescription[..maxExistingDescriptionLength];
+
+        return $"{trimmedDescription}{separator}{AutoEndNote}";
     }
 }

--- a/attendance_monitoring/Services/FingerprintService.cs
+++ b/attendance_monitoring/Services/FingerprintService.cs
@@ -33,7 +33,8 @@ public class FingerprintService(
     IConfiguration configuration,
     IDataProtectionProvider dataProtectionProvider,
     ConfiguredTimeZoneProvider clock,
-    ILogger<FingerprintService> logger) : IFingerprintService
+    ILogger<FingerprintService> logger,
+    IAutomaticSessionEndService? automaticSessionEndService = null) : IFingerprintService
 {
     private readonly IAttendanceService _attendanceService = attendanceService;
     private readonly ConfiguredTimeZoneProvider _clock = clock;
@@ -532,6 +533,34 @@ public class FingerprintService(
                     MatchScore = matchScore
                 };
             }
+
+            if (automaticSessionEndService != null)
+            {
+                session = await automaticSessionEndService.AutoEndIfExpiredAsync(session).ConfigureAwait(false);
+            }
+
+            if (session.Status != SessionStatusConstants.Active)
+            {
+                if (scanEvent != null)
+                {
+                    scanEvent.Status = "Rejected";
+                    scanEvent.MatchedStudentId = student.Id;
+                    scanEvent.SessionId = session.Id;
+                    scanEvent.FailureReason = "Session is not active";
+                    context.FingerprintScanEvents.Add(scanEvent);
+                    await context.SaveChangesAsync().ConfigureAwait(false);
+                }
+
+                return new FingerprintScanResponseDto
+                {
+                    Success = false,
+                    Message = "Session is not active",
+                    StudentId = student.Id,
+                    StudentName = $"{student.Firstname} {student.Lastname}",
+                    MatchMethod = matchMethod,
+                    MatchScore = matchScore
+                };
+            }
         }
         else
         {
@@ -758,7 +787,14 @@ public class FingerprintService(
                          session.ActualStartTime <= now &&
                          (!session.ActualEndTime.HasValue || session.ActualEndTime > now)))
             {
-                return session;
+                var normalizedSession = automaticSessionEndService == null
+                    ? session
+                    : await automaticSessionEndService.AutoEndIfExpiredAsync(session).ConfigureAwait(false);
+
+                if (normalizedSession.Status == SessionStatusConstants.Active)
+                {
+                    return normalizedSession;
+                }
             }
         }
 

--- a/attendance_monitoring/Services/QrCode/QrCodeAuthorizationService.cs
+++ b/attendance_monitoring/Services/QrCode/QrCodeAuthorizationService.cs
@@ -8,6 +8,7 @@ namespace attendance_monitoring.Services.QrCode;
 internal sealed class QrCodeAuthorizationService
 {
     private readonly ISessionRepository _sessionRepository;
+    private readonly IAutomaticSessionEndService? _automaticSessionEndService;
     private readonly IStudentEnrollmentService _studentEnrollmentService;
     private readonly IUserContextService _userContextService;
     private readonly ILogger<QrCodeAuthorizationService> _logger;
@@ -16,9 +17,11 @@ internal sealed class QrCodeAuthorizationService
         ISessionRepository sessionRepository,
         IStudentEnrollmentService studentEnrollmentService,
         IUserContextService userContextService,
-        ILogger<QrCodeAuthorizationService> logger)
+        ILogger<QrCodeAuthorizationService> logger,
+        IAutomaticSessionEndService? automaticSessionEndService = null)
     {
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _automaticSessionEndService = automaticSessionEndService;
         _studentEnrollmentService = studentEnrollmentService ?? throw new ArgumentNullException(nameof(studentEnrollmentService));
         _userContextService = userContextService ?? throw new ArgumentNullException(nameof(userContextService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -37,6 +40,11 @@ internal sealed class QrCodeAuthorizationService
         {
             _logger.LogWarning("Session with ID {SessionId} not found", sessionId);
             return "The specified session does not exist";
+        }
+
+        if (_automaticSessionEndService != null)
+        {
+            session = await _automaticSessionEndService.AutoEndIfExpiredAsync(session).ConfigureAwait(false);
         }
 
         if (session.Status != SessionStatusConstants.Active)
@@ -66,6 +74,11 @@ internal sealed class QrCodeAuthorizationService
         {
             _logger.LogWarning("Session with ID {SessionId} not found", sessionId);
             throw new EntityNotFoundException<Guid>("Session", sessionId);
+        }
+
+        if (_automaticSessionEndService != null)
+        {
+            session = await _automaticSessionEndService.AutoEndIfExpiredAsync(session).ConfigureAwait(false);
         }
 
         if (session.Status != SessionStatusConstants.Active)

--- a/attendance_monitoring/Services/ReportsService.cs
+++ b/attendance_monitoring/Services/ReportsService.cs
@@ -21,7 +21,8 @@ public class ReportsService(
     IInstructorRepository instructorRepository,
     IScheduleRepository scheduleRepository,
     IUserContextService userContextService,
-    ILogger<ReportsService> logger) : IReportsService
+    ILogger<ReportsService> logger,
+    IAutomaticSessionEndService? automaticSessionEndService = null) : IReportsService
 {
     public Task<AttendanceSummaryDto> GetAttendanceSummaryAsync(AttendanceFilterRequest filter, ClaimsPrincipal user)
         => attendanceService.GetAttendanceSummaryAsync(filter, user);
@@ -68,6 +69,11 @@ public class ReportsService(
                     instructor.Id, sectionId);
                 throw new UnauthorizedAccessException("You can only view attendance reports for sections you teach");
             }
+        }
+
+        if (automaticSessionEndService != null)
+        {
+            await automaticSessionEndService.AutoEndExpiredSessionsAsync().ConfigureAwait(false);
         }
 
         var sessionRows = await sessionRepository
@@ -166,6 +172,11 @@ public class ReportsService(
                     currentInstructor.Id, instructorId);
                 throw new UnauthorizedAccessException("You can only view your own session reports");
             }
+        }
+
+        if (automaticSessionEndService != null)
+        {
+            await automaticSessionEndService.AutoEndExpiredSessionsAsync().ConfigureAwait(false);
         }
 
         var sessionRows = await sessionRepository

--- a/attendance_monitoring/Services/SessionService.cs
+++ b/attendance_monitoring/Services/SessionService.cs
@@ -25,6 +25,7 @@ public class SessionService : ISessionService
     private readonly INotificationService _notificationService;
     private readonly IUserContextService _userContextService;
     private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IAutomaticSessionEndService? _automaticSessionEndService;
     private readonly ConfiguredTimeZoneProvider _clock;
     private readonly ILogger<SessionService> _logger;
 
@@ -41,7 +42,8 @@ public class SessionService : ISessionService
         IUserContextService userContextService,
         IHttpContextAccessor httpContextAccessor,
         ConfiguredTimeZoneProvider clock,
-        ILogger<SessionService> logger)
+        ILogger<SessionService> logger,
+        IAutomaticSessionEndService? automaticSessionEndService = null)
     {
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
         _scheduleRepository = scheduleRepository ?? throw new ArgumentNullException(nameof(scheduleRepository));
@@ -51,6 +53,7 @@ public class SessionService : ISessionService
         _notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
         _userContextService = userContextService ?? throw new ArgumentNullException(nameof(userContextService));
         _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+        _automaticSessionEndService = automaticSessionEndService;
         _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -74,8 +77,10 @@ public class SessionService : ISessionService
                 throw new EntityNotFoundException<Guid>("Session", id);
             }
 
+            var normalizedSession = await NormalizeExpiredSessionAsync(session).ConfigureAwait(false);
+
             _logger.LogInformation("Successfully retrieved session with ID: {SessionId}", id);
-            return MapToResponseDto(session);
+            return MapToResponseDto(normalizedSession);
         }
         catch (EntityNotFoundException<Guid>)
         {
@@ -101,8 +106,10 @@ public class SessionService : ISessionService
             var sessions = await _sessionRepository.GetAllSessionsAsync().ConfigureAwait(false);
             var sessionList = sessions.ToList();
 
+            var normalizedSessions = await NormalizeExpiredSessionsAsync(sessionList).ConfigureAwait(false);
+
             _logger.LogInformation("Successfully retrieved {Count} sessions", sessionList.Count);
-            return sessionList.Select(MapToResponseDto);
+            return normalizedSessions.Select(MapToResponseDto);
         }
         catch (Exception ex)
         {
@@ -124,9 +131,11 @@ public class SessionService : ISessionService
             var sessions = await _sessionRepository.GetSessionsByScheduleIdAsync(scheduleId).ConfigureAwait(false);
             var sessionList = sessions.ToList();
 
+            var normalizedSessions = await NormalizeExpiredSessionsAsync(sessionList).ConfigureAwait(false);
+
             _logger.LogInformation("Successfully retrieved {Count} sessions for schedule ID: {ScheduleId}",
                 sessionList.Count, scheduleId);
-            return sessionList.Select(MapToResponseDto);
+            return normalizedSessions.Select(MapToResponseDto);
         }
         catch (Exception ex)
         {
@@ -159,9 +168,13 @@ public class SessionService : ISessionService
             var sessions = await _sessionRepository.GetSessionsByStatusAsync(status).ConfigureAwait(false);
             var sessionList = sessions.ToList();
 
+            var normalizedSessions = await NormalizeExpiredSessionsAsync(sessionList).ConfigureAwait(false);
+
             _logger.LogInformation("Successfully retrieved {Count} sessions with status: {Status}",
                 sessionList.Count, status);
-            return sessionList.Select(MapToResponseDto);
+            return normalizedSessions
+                .Where(session => session.Status == status)
+                .Select(MapToResponseDto);
         }
         catch (Exception ex)
         {
@@ -183,9 +196,11 @@ public class SessionService : ISessionService
             var sessions = await _sessionRepository.GetSessionsByDateAsync(date).ConfigureAwait(false);
             var sessionList = sessions.ToList();
 
+            var normalizedSessions = await NormalizeExpiredSessionsAsync(sessionList).ConfigureAwait(false);
+
             _logger.LogInformation("Successfully retrieved {Count} sessions for date: {Date:yyyy-MM-dd}",
                 sessionList.Count, date);
-            return sessionList.Select(MapToResponseDto);
+            return normalizedSessions.Select(MapToResponseDto);
         }
         catch (Exception ex)
         {
@@ -237,7 +252,9 @@ public class SessionService : ISessionService
             _logger.LogInformation("Successfully retrieved {Count} sessions for instructor ID: {InstructorId}",
                 sessionList.Count, instructor.Id);
 
-            return sessionList.Select(MapToResponseDto);
+            var normalizedSessions = await NormalizeExpiredSessionsAsync(sessionList).ConfigureAwait(false);
+
+            return normalizedSessions.Select(MapToResponseDto);
         }
         catch (EntityUnauthorizedException)
         {
@@ -285,6 +302,8 @@ public class SessionService : ISessionService
                 _logger.LogWarning("Session with ID {SessionId} not found", sessionId);
                 throw new EntityNotFoundException<Guid>("Session", sessionId);
             }
+
+            session = await NormalizeExpiredSessionAsync(session).ConfigureAwait(false);
 
             // Validate session status - only active sessions can have room changes
             if (session.Status != SessionStatusConstants.Active)
@@ -682,6 +701,8 @@ public class SessionService : ISessionService
                 throw new EntityUnauthorizedException("Session", "End", userId, errorMessage);
             }
 
+            session = await NormalizeExpiredSessionAsync(session).ConfigureAwait(false);
+
             // Validate session status - only active sessions can be ended
             if (session.Status != SessionStatusConstants.Active)
             {
@@ -959,6 +980,24 @@ public class SessionService : ISessionService
         }
     }
 
+    private async Task<Session> NormalizeExpiredSessionAsync(Session session)
+    {
+        return _automaticSessionEndService == null
+            ? session
+            : await _automaticSessionEndService.AutoEndIfExpiredAsync(session).ConfigureAwait(false);
+    }
+
+    private async Task<List<Session>> NormalizeExpiredSessionsAsync(IEnumerable<Session> sessions)
+    {
+        var normalized = new List<Session>();
+        foreach (var session in sessions)
+        {
+            normalized.Add(await NormalizeExpiredSessionAsync(session).ConfigureAwait(false));
+        }
+
+        return normalized;
+    }
+
     #endregion
 
     #region UUID Entrypoints
@@ -970,7 +1009,8 @@ public class SessionService : ISessionService
         {
             throw new EntityNotFoundException<Guid>("Session", id);
         }
-        return MapToResponseDto(session);
+        var normalizedSession = await NormalizeExpiredSessionAsync(session).ConfigureAwait(false);
+        return MapToResponseDto(normalizedSession);
     }
 
     public async Task<SessionResponseDto> StartSessionByUuidAsync(Guid sessionUuid, StartSession request)

--- a/attendance_monitoring/Services/SessionService.cs
+++ b/attendance_monitoring/Services/SessionService.cs
@@ -165,7 +165,9 @@ public class SessionService : ISessionService
 
         try
         {
-            var sessions = await _sessionRepository.GetSessionsByStatusAsync(status).ConfigureAwait(false);
+            var sessions = status == SessionStatusConstants.Ended
+                ? await _sessionRepository.GetAllSessionsAsync().ConfigureAwait(false)
+                : await _sessionRepository.GetSessionsByStatusAsync(status).ConfigureAwait(false);
             var sessionList = sessions.ToList();
 
             var normalizedSessions = await NormalizeExpiredSessionsAsync(sessionList).ConfigureAwait(false);

--- a/attendance_monitoring/Services/SessionService.cs
+++ b/attendance_monitoring/Services/SessionService.cs
@@ -165,7 +165,7 @@ public class SessionService : ISessionService
 
         try
         {
-            // When requesting "ended" sessions, fetch both Active and Ended statuses.
+            // When requesting SessionStatusConstants.Ended sessions, fetch both Active and Ended statuses.
             // Active sessions are needed for NormalizeExpiredSessionsAsync which converts
             // expired active sessions to ended status. Cancelled and not_started sessions
             // are not needed for this operation.

--- a/attendance_monitoring/Services/SessionService.cs
+++ b/attendance_monitoring/Services/SessionService.cs
@@ -165,8 +165,15 @@ public class SessionService : ISessionService
 
         try
         {
+            // When requesting "ended" sessions, fetch both Active and Ended statuses.
+            // Active sessions are needed for NormalizeExpiredSessionsAsync which converts
+            // expired active sessions to ended status. Cancelled and not_started sessions
+            // are not needed for this operation.
             var sessions = status == SessionStatusConstants.Ended
-                ? await _sessionRepository.GetAllSessionsAsync().ConfigureAwait(false)
+                ? await _sessionRepository.GetSessionsByStatusesAsync([
+                    SessionStatusConstants.Active,
+                    SessionStatusConstants.Ended
+                ]).ConfigureAwait(false)
                 : await _sessionRepository.GetSessionsByStatusAsync(status).ConfigureAwait(false);
             var sessionList = sessions.ToList();
 

--- a/attendance_monitoring/appsettings.json
+++ b/attendance_monitoring/appsettings.json
@@ -38,6 +38,11 @@
 	"TimeZoneSettings": {
 		"TimeZoneId": "Asia/Manila"
 	},
+	"SessionAutoEnd": {
+		"Enabled": true,
+		"GraceMinutes": 15,
+		"ScanIntervalMinutes": 5
+	},
 	"Kestrel": {
 		"Endpoints": {
 			"Http": {


### PR DESCRIPTION
- SessionAutoEnd configuration section
- NormalizeExpiredSessionAsync and NormalizeExpiredSessionAsync methods
- I

----
## Summary by Gitar

- **Background service:**
  - Added `AutomaticSessionEndBackgroundService` to periodically process expired sessions via `IAutomaticSessionEndService`.
- **Service integration:**
  - Updated `SessionService`, `FingerprintService`, `AttendanceService`, `QrCodeAuthorizationService`, and `ReportsService` to automatically trigger session normalization/ending.
- **Data access:**
  - Added `GetActiveSessionsForAutoEndScanAsync` to `SessionRepository` to support background scanning.
- **Configuration:**
  - Introduced `SessionAutoEndOptions` and added corresponding settings to `appsettings.json` and `.env.example`.
- **Testing:**
  - Added comprehensive unit tests for `AutomaticSessionEndService` and `AutomaticSessionEndBackgroundService`, and integrated mocks into existing service tests.


<sub>This will update automatically on new commits.</sub>