### PR TITLE
Feat/notifications

### DIFF
--- a/attendance.testproject/Integration_Testing/NotificationHubAuthIntegrationTests.cs
+++ b/attendance.testproject/Integration_Testing/NotificationHubAuthIntegrationTests.cs
@@ -43,6 +43,16 @@ public sealed class NotificationHubAuthIntegrationTests
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
+    [Fact]
+    public async Task PostNotificationHubNegotiate_AcceptsValidAccessTokenQueryString()
+    {
+        await using var host = await CreateHostAsync();
+
+        var response = await host.Client.PostAsync($"/notificationHub/negotiate?negotiateVersion=1&access_token={CreateJwt()}", null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
     private static async Task<SignalRAuthHost> CreateHostAsync()
     {
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions

--- a/attendance.testproject/Integration_Testing/NotificationHubAuthIntegrationTests.cs
+++ b/attendance.testproject/Integration_Testing/NotificationHubAuthIntegrationTests.cs
@@ -1,0 +1,119 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Security.Claims;
+using System.Text;
+using attendance_monitoring.Extensions;
+using attendance_monitoring.Extensions.ServiceCollectionExtensions;
+using attendance_monitoring.IServices;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.IdentityModel.Tokens;
+
+namespace attendance.testproject.Integration_Testing;
+
+public sealed class NotificationHubAuthIntegrationTests
+{
+    private const string JwtSecret = "test-secret-key-for-integration-testing-minimum-32-characters";
+    private const string JwtIssuer = "test-issuer";
+    private const string JwtAudience = "test-audience";
+
+    [Fact]
+    public async Task PostNotificationHubNegotiate_RejectsUnauthenticatedRequests()
+    {
+        await using var host = await CreateHostAsync();
+
+        var response = await host.Client.PostAsync("/notificationHub/negotiate?negotiateVersion=1", null);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostNotificationHubNegotiate_AcceptsValidAccessTokenCookie()
+    {
+        await using var host = await CreateHostAsync();
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/notificationHub/negotiate?negotiateVersion=1");
+        request.Headers.Add("Cookie", $"accessToken={CreateJwt()}");
+
+        var response = await host.Client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    private static async Task<SignalRAuthHost> CreateHostAsync()
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = Environments.Production
+        });
+
+        builder.WebHost.UseTestServer();
+        builder.Services.AddLogging();
+        builder.Services.AddRouting();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["AppSettings:Token"] = JwtSecret,
+            ["AppSettings:Issuer"] = JwtIssuer,
+            ["AppSettings:Audience"] = JwtAudience,
+            ["TimeZoneSettings:TimeZoneId"] = TimeZoneInfo.Local.Id,
+            ["SessionAutoEnd:Enabled"] = "false"
+        });
+
+        var tokenValidationService = new Mock<ITokenValidationService>(MockBehavior.Strict);
+        tokenValidationService
+            .Setup(service => service.IsTokenBlacklistedAsync(It.IsAny<string>()))
+            .ReturnsAsync(false);
+
+        builder.Services.AddSingleton(tokenValidationService.Object);
+        builder.Services.AddAuthenticationServices(builder.Configuration);
+        builder.Services.AddAuthorizationPolicies();
+        builder.Services.AddSignalRServices();
+
+        var app = builder.Build();
+        app.UseRouting();
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.MapSignalRHubs();
+
+        await app.StartAsync();
+        var client = app.GetTestClient();
+        client.BaseAddress = new Uri("https://localhost");
+
+        return new SignalRAuthHost(app, client);
+    }
+
+    private static string CreateJwt()
+    {
+        var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(JwtSecret));
+        var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            issuer: JwtIssuer,
+            audience: JwtAudience,
+            claims:
+            [
+                new Claim(ClaimTypes.NameIdentifier, "admin-1"),
+                new Claim(ClaimTypes.Name, "admin"),
+                new Claim(ClaimTypes.Role, "Admin"),
+                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N"))
+            ],
+            expires: DateTime.UtcNow.AddMinutes(15),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private sealed class SignalRAuthHost(WebApplication app, HttpClient client) : IAsyncDisposable
+    {
+        public HttpClient Client { get; } = client;
+
+        public async ValueTask DisposeAsync()
+        {
+            await app.StopAsync();
+            Client.Dispose();
+            await app.DisposeAsync();
+        }
+    }
+}

--- a/attendance.testproject/Services_Testing/NotificationServiceTest.cs
+++ b/attendance.testproject/Services_Testing/NotificationServiceTest.cs
@@ -25,6 +25,7 @@ public class NotificationServiceTest
         await service.NotifySessionStartedAsync(sessionId, studentIds, instructorId);
 
         // Assert
+        Assert.Equal(3, sentNotifications.Count);
         Assert.Equal(["student-1-connection"], sentNotifications[0].Connections);
         Assert.Equal(["student-2-connection"], sentNotifications[1].Connections);
         Assert.Equal(["instructor-1-connection"], sentNotifications[2].Connections);
@@ -50,6 +51,7 @@ public class NotificationServiceTest
         await service.NotifySessionEndedAsync(sessionId, studentIds, instructorId);
 
         // Assert
+        Assert.Equal(3, sentNotifications.Count);
         Assert.Equal(["student-1-connection"], sentNotifications[0].Connections);
         Assert.Equal(["student-2-connection"], sentNotifications[1].Connections);
         Assert.Equal(["instructor-1-connection"], sentNotifications[2].Connections);
@@ -79,6 +81,40 @@ public class NotificationServiceTest
         var sent = Assert.Single(sentNotifications);
         Assert.Equal(["student-1-connection"], sent.Connections);
         Assert.Equal("Attendance Recorded", sent.Notification.Title);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task SendToUserAsync_InvalidUserId_DoesNotQueryConnectionManager(string? userId)
+    {
+        // Arrange
+        var hubContext = new Mock<IHubContext<NotificationHub>>();
+        var connectionManager = new Mock<IUserConnectionManager>(MockBehavior.Strict);
+        var service = new NotificationService(
+            hubContext.Object,
+            connectionManager.Object,
+            Mock.Of<INotificationPreferenceService>(),
+            Mock.Of<IQrCodeRepository>(),
+            Mock.Of<ISessionRepository>(),
+            Mock.Of<IStudentRepository>(),
+            Mock.Of<ILogger<NotificationService>>());
+
+        var notification = new NotificationDto
+        {
+            Title = "Session Started",
+            Message = "Test notification",
+            Type = "Info",
+            Category = "Session"
+        };
+
+        // Act
+        await service.SendToUserAsync(userId!, notification);
+
+        // Assert
+        connectionManager.Verify(
+            manager => manager.IsOnlineAsync(It.IsAny<string>()),
+            Times.Never);
     }
 
     private static NotificationService CreateNotificationService(

--- a/attendance.testproject/Services_Testing/NotificationServiceTest.cs
+++ b/attendance.testproject/Services_Testing/NotificationServiceTest.cs
@@ -1,0 +1,158 @@
+using attendance_monitoring.Classes;
+using attendance_monitoring.Hubs;
+using attendance_monitoring.IRepository;
+using attendance_monitoring.IServices;
+using attendance_monitoring.Models.DTO.Response;
+using attendance_monitoring.Services;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+
+namespace attendance.testproject.Services_Testing;
+
+public class NotificationServiceTest
+{
+    [Fact]
+    public async Task NotifySessionStartedAsync_SendsReceiveNotificationToStudentsAndInstructorOnly()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var studentIds = new[] { "student-1", "student-2" };
+        const string instructorId = "instructor-1";
+        var sentNotifications = new List<(IReadOnlyList<string> Connections, NotificationDto Notification)>();
+        var service = CreateNotificationService(sessionId, sentNotifications);
+
+        // Act
+        await service.NotifySessionStartedAsync(sessionId, studentIds, instructorId);
+
+        // Assert
+        Assert.Equal(["student-1-connection"], sentNotifications[0].Connections);
+        Assert.Equal(["student-2-connection"], sentNotifications[1].Connections);
+        Assert.Equal(["instructor-1-connection"], sentNotifications[2].Connections);
+        Assert.All(sentNotifications, sent =>
+        {
+            Assert.Equal("Session Started", sent.Notification.Title);
+            Assert.Equal("Session", sent.Notification.Category);
+            Assert.NotNull(sent.Notification.Metadata);
+        });
+    }
+
+    [Fact]
+    public async Task NotifySessionEndedAsync_SendsReceiveNotificationToStudentsAndInstructorOnly()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var studentIds = new[] { "student-1", "student-2" };
+        const string instructorId = "instructor-1";
+        var sentNotifications = new List<(IReadOnlyList<string> Connections, NotificationDto Notification)>();
+        var service = CreateNotificationService(sessionId, sentNotifications);
+
+        // Act
+        await service.NotifySessionEndedAsync(sessionId, studentIds, instructorId);
+
+        // Assert
+        Assert.Equal(["student-1-connection"], sentNotifications[0].Connections);
+        Assert.Equal(["student-2-connection"], sentNotifications[1].Connections);
+        Assert.Equal(["instructor-1-connection"], sentNotifications[2].Connections);
+        Assert.All(sentNotifications, sent =>
+        {
+            Assert.Equal("Session Ended", sent.Notification.Title);
+            Assert.Equal("Session", sent.Notification.Category);
+            Assert.NotNull(sent.Notification.Metadata);
+        });
+    }
+
+    [Fact]
+    public async Task NotifyStudentCheckedInAsync_StillHonorsInstructorRealtimePreference()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var sentNotifications = new List<(IReadOnlyList<string> Connections, NotificationDto Notification)>();
+        var service = CreateNotificationService(
+            sessionId,
+            sentNotifications,
+            instructorRealtimePreference: false);
+
+        // Act
+        await service.NotifyStudentCheckedInAsync("student-1", "instructor-1", sessionId, "Present");
+
+        // Assert
+        var sent = Assert.Single(sentNotifications);
+        Assert.Equal(["student-1-connection"], sent.Connections);
+        Assert.Equal("Attendance Recorded", sent.Notification.Title);
+    }
+
+    private static NotificationService CreateNotificationService(
+        Guid sessionId,
+        List<(IReadOnlyList<string> Connections, NotificationDto Notification)> sentNotifications,
+        bool instructorRealtimePreference = true)
+    {
+        var hubContext = new Mock<IHubContext<NotificationHub>>();
+        var clients = new Mock<IHubClients>();
+        var clientProxy = new Mock<IClientProxy>();
+        var connectionManager = new Mock<IUserConnectionManager>();
+        var preferenceService = new Mock<INotificationPreferenceService>();
+        var qrCodeRepository = new Mock<IQrCodeRepository>();
+        var sessionRepository = new Mock<ISessionRepository>();
+        var studentRepository = new Mock<IStudentRepository>();
+        var logger = new Mock<ILogger<NotificationService>>();
+
+        hubContext.SetupGet(context => context.Clients).Returns(clients.Object);
+        clients
+            .Setup(client => client.Clients(It.IsAny<IReadOnlyList<string>>()))
+            .Callback<IReadOnlyList<string>>(connections => sentNotifications.Add((connections, null!)))
+            .Returns(clientProxy.Object);
+        clientProxy
+            .Setup(proxy => proxy.SendCoreAsync(
+                "ReceiveNotification",
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, object?[], CancellationToken>((_, args, _) =>
+            {
+                var index = sentNotifications.Count - 1;
+                sentNotifications[index] = (
+                    sentNotifications[index].Connections,
+                    Assert.IsType<NotificationDto>(args[0]));
+            })
+            .Returns(Task.CompletedTask);
+
+        foreach (var userId in new[] { "student-1", "student-2", "instructor-1", "admin-1", "instructor-2" })
+        {
+            connectionManager.Setup(manager => manager.IsOnlineAsync(userId)).ReturnsAsync(true);
+            connectionManager.Setup(manager => manager.GetConnectionsAsync(userId)).ReturnsAsync([$"{userId}-connection"]);
+        }
+
+        preferenceService
+            .Setup(service => service.GetRealtimeCheckInAsync("instructor-1"))
+            .ReturnsAsync(instructorRealtimePreference);
+
+        sessionRepository
+            .Setup(repository => repository.GetSessionByIdAsync(sessionId))
+            .ReturnsAsync(new Session
+            {
+                Id = sessionId,
+                Schedule = new Schedules
+                {
+                    Subject = new Subject { Name = "Algorithms" }
+                }
+            });
+
+        studentRepository
+            .Setup(repository => repository.GetStudentByUserIdAsync("student-1"))
+            .ReturnsAsync(new Student
+            {
+                Firstname = "Ada",
+                Lastname = "Lovelace",
+                UserId = "student-1",
+                Usn = Student.CreatePendingUsn()
+            });
+
+        return new NotificationService(
+            hubContext.Object,
+            connectionManager.Object,
+            preferenceService.Object,
+            qrCodeRepository.Object,
+            sessionRepository.Object,
+            studentRepository.Object,
+            logger.Object);
+    }
+}

--- a/attendance.testproject/Services_Testing/SessionServiceTest.cs
+++ b/attendance.testproject/Services_Testing/SessionServiceTest.cs
@@ -707,6 +707,11 @@ public class SessionServiceTest
             .Setup(r => r.GetSessionByIdAsync(sessionId))
             .ReturnsAsync(() => session); // Return the updated session
 
+        var studentUserIds = new[] { "student-1", "student-2" };
+        _mockEnrollmentRepository
+            .Setup(r => r.GetActiveSectionEnrollmentsAsync(session.Schedule.SectionId))
+            .ReturnsAsync(CreateTestEnrollments(session.Schedule.SectionId, session.Schedule.SubjectId, studentUserIds));
+
         // Act
         var beforeStart = DateTime.Now;
         var result = await _sessionService.StartSessionAsync(sessionId, request);
@@ -743,6 +748,11 @@ public class SessionServiceTest
                 s.RowVersion != null &&
                 s.RowVersion.SequenceEqual(request.RowVersion)
             )), Times.Once);
+
+        _mockNotificationService.Verify(n => n.NotifySessionStartedAsync(
+            sessionId,
+            It.Is<IEnumerable<string>>(ids => studentUserIds.All(ids.Contains)),
+            instructor.UserId), Times.Once);
     }
 
     [Fact]
@@ -1049,6 +1059,11 @@ public class SessionServiceTest
             .Setup(r => r.GetSessionByIdAsync(session.Id))
             .ReturnsAsync(() => session); // Return the updated session
 
+        var studentUserIds = new[] { "student-1", "student-2" };
+        _mockEnrollmentRepository
+            .Setup(r => r.GetActiveSectionEnrollmentsAsync(session.Schedule.SectionId))
+            .ReturnsAsync(CreateTestEnrollments(session.Schedule.SectionId, session.Schedule.SubjectId, studentUserIds));
+
         // Act
         var beforeEnd = DateTime.Now;
         var result = await _sessionService.EndSessionAsync(sessionId, request);
@@ -1079,6 +1094,11 @@ public class SessionServiceTest
                 s.RowVersion != null &&
                 s.RowVersion.SequenceEqual(request.RowVersion)
             )), Times.Once);
+
+        _mockNotificationService.Verify(n => n.NotifySessionEndedAsync(
+            sessionId,
+            It.Is<IEnumerable<string>>(ids => studentUserIds.All(ids.Contains)),
+            instructor.UserId), Times.Once);
     }
 
     [Fact]
@@ -1705,6 +1725,32 @@ public class SessionServiceTest
             CreatedAt = DateTime.UtcNow,
             UpdatedAt = DateTime.UtcNow
         };
+    }
+
+    private static List<StudentEnrollment> CreateTestEnrollments(
+        Guid sectionId,
+        Guid subjectId,
+        IEnumerable<string> studentUserIds)
+    {
+        return studentUserIds
+            .Select(userId => new StudentEnrollment
+            {
+                Id = Guid.NewGuid(),
+                StudentId = Guid.NewGuid(),
+                SectionId = sectionId,
+                SubjectId = subjectId,
+                IsActive = true,
+                Student = new Student
+                {
+                    Id = Guid.NewGuid(),
+                    Firstname = "Test",
+                    Lastname = "Student",
+                    Usn = Student.CreatePendingUsn(),
+                    UserId = userId,
+                    SectionId = sectionId
+                }
+            })
+            .ToList();
     }
 
     [Fact]

--- a/attendance_monitoring/Extensions/ServiceCollectionExtensions/AuthenticationServiceExtensions.cs
+++ b/attendance_monitoring/Extensions/ServiceCollectionExtensions/AuthenticationServiceExtensions.cs
@@ -55,11 +55,20 @@ public static class AuthenticationServiceExtensions
             {
                 OnMessageReceived = context =>
                 {
-                    // If the request is for a web endpoint and contains cookies, use the cookie token
-                    if (context.Request.Cookies.ContainsKey("accessToken"))
+                    var path = context.HttpContext.Request.Path;
+
+                    // For SignalR connections, check query string token first
+                    var accessToken = context.Request.Query["access_token"];
+                    if (!string.IsNullOrEmpty(accessToken) && path.StartsWithSegments("/notificationHub"))
+                    {
+                        context.Token = accessToken;
+                    }
+                    // Otherwise fall back to cookie for web endpoints
+                    else if (context.Request.Cookies.ContainsKey("accessToken"))
                     {
                         context.Token = context.Request.Cookies["accessToken"];
                     }
+
                     return Task.CompletedTask;
                 },
                 OnTokenValidated = async context =>

--- a/attendance_monitoring/IServices/INotificationService.cs
+++ b/attendance_monitoring/IServices/INotificationService.cs
@@ -11,6 +11,6 @@ public interface INotificationService
     // Specialized methods for critical scenarios
     Task NotifyQrCodeGeneratedAsync(Guid qrCodeId, string instructorId);
     Task NotifyStudentCheckedInAsync(string studentId, string instructorId, Guid sessionId, string status);
-    Task NotifySessionStartedAsync(Guid sessionId, IEnumerable<string> studentIds);
-    Task NotifySessionEndedAsync(Guid sessionId, IEnumerable<string> studentIds);
+    Task NotifySessionStartedAsync(Guid sessionId, IEnumerable<string> studentIds, string instructorId);
+    Task NotifySessionEndedAsync(Guid sessionId, IEnumerable<string> studentIds, string instructorId);
 }

--- a/attendance_monitoring/Services/NotificationService.cs
+++ b/attendance_monitoring/Services/NotificationService.cs
@@ -36,6 +36,12 @@ public class NotificationService : INotificationService
 
     public async Task SendToUserAsync(string userId, NotificationDto notification)
     {
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            _logger.LogWarning("Notification not delivered because user ID is missing: {Title}", notification.Title);
+            return;
+        }
+
         try
         {
             if (await _connectionManager.IsOnlineAsync(userId))

--- a/attendance_monitoring/Services/NotificationService.cs
+++ b/attendance_monitoring/Services/NotificationService.cs
@@ -154,7 +154,7 @@ public class NotificationService : INotificationService
         }
     }
 
-    public async Task NotifySessionStartedAsync(Guid sessionId, IEnumerable<string> studentIds)
+    public async Task NotifySessionStartedAsync(Guid sessionId, IEnumerable<string> studentIds, string instructorId)
     {
         try
         {
@@ -170,12 +170,18 @@ public class NotificationService : INotificationService
                 Metadata = new { SessionId = sessionId }
             };
 
-            foreach (var studentId in studentIds)
+            var studentRecipients = studentIds.Distinct().ToList();
+            foreach (var studentId in studentRecipients)
             {
                 await SendToUserAsync(studentId, notification);
             }
 
-            _logger.LogInformation("Session started notification sent to {Count} students", studentIds.Count());
+            await SendToUserAsync(instructorId, notification);
+
+            _logger.LogInformation(
+                "Session started notification sent to {StudentCount} students and instructor {InstructorId}",
+                studentRecipients.Count,
+                instructorId);
         }
         catch (Exception ex)
         {
@@ -183,7 +189,7 @@ public class NotificationService : INotificationService
         }
     }
 
-    public async Task NotifySessionEndedAsync(Guid sessionId, IEnumerable<string> studentIds)
+    public async Task NotifySessionEndedAsync(Guid sessionId, IEnumerable<string> studentIds, string instructorId)
     {
         try
         {
@@ -199,12 +205,18 @@ public class NotificationService : INotificationService
                 Metadata = new { SessionId = sessionId }
             };
 
-            foreach (var studentId in studentIds)
+            var studentRecipients = studentIds.Distinct().ToList();
+            foreach (var studentId in studentRecipients)
             {
                 await SendToUserAsync(studentId, notification);
             }
 
-            _logger.LogInformation("Session ended notification sent to {Count} students", studentIds.Count());
+            await SendToUserAsync(instructorId, notification);
+
+            _logger.LogInformation(
+                "Session ended notification sent to {StudentCount} students and instructor {InstructorId}",
+                studentRecipients.Count,
+                instructorId);
         }
         catch (Exception ex)
         {

--- a/attendance_monitoring/Services/SessionService.cs
+++ b/attendance_monitoring/Services/SessionService.cs
@@ -619,9 +619,9 @@ public class SessionService : ISessionService
             _logger.LogInformation("Successfully started session ID: {SessionId} by instructor ID: {InstructorId}",
                 sessionId, instructor.Id);
 
-            // Send real-time notification to enrolled students
+            // Send real-time notification to enrolled students and the responsible instructor
             var enrolledStudentIds = await GetEnrolledStudentIdsAsync(sessionId).ConfigureAwait(false);
-            await _notificationService.NotifySessionStartedAsync(sessionId, enrolledStudentIds).ConfigureAwait(false);
+            await _notificationService.NotifySessionStartedAsync(sessionId, enrolledStudentIds, instructor.UserId).ConfigureAwait(false);
 
             // Retrieve updated session with navigation properties
             var updatedSession = await _sessionRepository.GetSessionByIdAsync(sessionId).ConfigureAwait(false);
@@ -747,9 +747,9 @@ public class SessionService : ISessionService
             _logger.LogInformation("Successfully ended session ID: {SessionId} by instructor ID: {InstructorId}",
                 sessionId, instructor.Id);
 
-            // Send real-time notification to enrolled students
+            // Send real-time notification to enrolled students and the responsible instructor
             var enrolledStudentIds = await GetEnrolledStudentIdsAsync(sessionId).ConfigureAwait(false);
-            await _notificationService.NotifySessionEndedAsync(sessionId, enrolledStudentIds).ConfigureAwait(false);
+            await _notificationService.NotifySessionEndedAsync(sessionId, enrolledStudentIds, instructor.UserId).ConfigureAwait(false);
 
             // Retrieve updated session with navigation properties
             var updatedSession = await _sessionRepository.GetSessionByIdAsync(sessionId).ConfigureAwait(false);


### PR DESCRIPTION
----
## Summary by Gitar

- **Authentication:**
  - Enabled SignalR authentication via `access_token` query string parameter in `AuthenticationServiceExtensions`.
- **Notifications:**
  - Updated `NotificationService` and `SessionService` to include instructors in session start/end notifications.
- **Testing:**
  - Added `NotificationHubAuthIntegrationTests` and `NotificationServiceTest` to cover new authentication and notification logic.


<sub>This will update automatically on new commits.</sub>