### PR TITLE
refactor:  create Generic CrudService module to remove boilerplate

### DIFF
--- a/attendance.testproject/Services_Testing/AdminDataServiceTests.cs
+++ b/attendance.testproject/Services_Testing/AdminDataServiceTests.cs
@@ -9,6 +9,7 @@ using attendance_monitoring.Options;
 using attendance_monitoring.Repositories;
 using attendance_monitoring.Services;
 using attendance_monitoring.Services.AdminData;
+using attendance_monitoring.Services.Crud;
 using ClosedXML.Excel;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
@@ -765,7 +766,11 @@ public class AdminDataServiceTests
             .ReturnsAsync(Array.Empty<GetAllUsersDto>());
 
         var classroomRepository = new ClassroomRepository(context);
-        var classroomService = new ClassroomService(classroomRepository, Mock.Of<ILogger<ClassroomService>>());
+        var classroomCrudService = new CrudService<Classroom, CreateClassroom, UpdateClassroom>(
+            new GenericCrudRepository<Classroom>(context),
+            ClassroomConfig.Create(classroomRepository),
+            Mock.Of<ILogger<CrudService<Classroom, CreateClassroom, UpdateClassroom>>>());
+        var classroomService = new ClassroomService(classroomCrudService, classroomRepository, Mock.Of<ILogger<ClassroomService>>());
         var service = new AdminDataService(
             context,
             accountService.Object,
@@ -1355,7 +1360,11 @@ public class AdminDataServiceTests
             .ReturnsAsync(Array.Empty<GetAllUsersDto>());
 
         var classroomRepository = new ClassroomRepository(context);
-        var classroomService = new ClassroomService(classroomRepository, Mock.Of<ILogger<ClassroomService>>());
+        var classroomCrudService = new CrudService<Classroom, CreateClassroom, UpdateClassroom>(
+            new GenericCrudRepository<Classroom>(context),
+            ClassroomConfig.Create(classroomRepository),
+            Mock.Of<ILogger<CrudService<Classroom, CreateClassroom, UpdateClassroom>>>());
+        var classroomService = new ClassroomService(classroomCrudService, classroomRepository, Mock.Of<ILogger<ClassroomService>>());
         var service = new AdminDataService(
             context,
             accountService.Object,

--- a/attendance.testproject/Services_Testing/ClassroomServiceTest.cs
+++ b/attendance.testproject/Services_Testing/ClassroomServiceTest.cs
@@ -3,7 +3,7 @@ using attendance_monitoring.Exceptions;
 using attendance_monitoring.IRepository;
 using attendance_monitoring.Models.DTO.Request;
 using attendance_monitoring.Services;
-using Microsoft.EntityFrameworkCore;
+using attendance_monitoring.Services.Crud;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -12,482 +12,215 @@ namespace attendance.testproject.Services_Testing;
 public class ClassroomServiceTest
 {
     private readonly Mock<IClassroomRepository> _mockClassroomRepository;
+    private readonly Mock<ICrudService<Classroom, CreateClassroom, UpdateClassroom>> _mockCrudService;
     private readonly Mock<ILogger<ClassroomService>> _mockLogger;
     private readonly ClassroomService _service;
 
     public ClassroomServiceTest()
     {
         _mockClassroomRepository = new Mock<IClassroomRepository>();
+        _mockCrudService = new Mock<ICrudService<Classroom, CreateClassroom, UpdateClassroom>>();
         _mockLogger = new Mock<ILogger<ClassroomService>>();
-        _service = new ClassroomService(_mockClassroomRepository.Object, _mockLogger.Object);
+        _service = new ClassroomService(_mockCrudService.Object, _mockClassroomRepository.Object, _mockLogger.Object);
     }
 
-    [Fact]
-    public void Constructor_NullRepository_ThrowsArgumentNullException()
-    {
-        var exception = Assert.Throws<ArgumentNullException>(() => new ClassroomService(null!, _mockLogger.Object));
-
-        Assert.Equal("classroomRepository", exception.ParamName);
-    }
+    #region GetAllClassroomsAsync
 
     [Fact]
-    public void Constructor_NullLogger_ThrowsArgumentNullException()
-    {
-        var exception = Assert.Throws<ArgumentNullException>(() => new ClassroomService(_mockClassroomRepository.Object, null!));
-
-        Assert.Equal("logger", exception.ParamName);
-    }
-
-    [Fact]
-    public async Task GetAllClassroomsAsync_ReturnsMaterializedClassrooms()
+    public async Task GetAllClassroomsAsync_DelegatesToCrudService()
     {
         var classrooms = new List<Classroom>
         {
             new() { Id = Guid.NewGuid(), Name = "Room A" },
             new() { Id = Guid.NewGuid(), Name = "Room B" },
         };
-
-        _mockClassroomRepository
-            .Setup(repository => repository.GetAllClassroomsAsync())
-            .ReturnsAsync(classrooms);
+        _mockCrudService.Setup(s => s.GetAllAsync()).ReturnsAsync(classrooms);
 
         var result = await _service.GetAllClassroomsAsync();
 
-        var materialized = Assert.IsType<List<Classroom>>(result);
-        Assert.Collection(materialized,
-            classroom => Assert.Equal("Room A", classroom.Name),
-            classroom => Assert.Equal("Room B", classroom.Name));
+        Assert.Equal(classrooms, result);
+        _mockCrudService.Verify(s => s.GetAllAsync(), Times.Once);
     }
 
-    [Fact]
-    public async Task GetAllClassroomsAsync_WrapsUnexpectedFailures()
-    {
-        var expectedException = new InvalidOperationException("Lookup failed");
-        _mockClassroomRepository
-            .Setup(repository => repository.GetAllClassroomsAsync())
-            .ThrowsAsync(expectedException);
+    #endregion
 
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.GetAllClassroomsAsync());
-
-        Assert.Equal("Classroom", exception.EntityName);
-        Assert.Equal("GetAllClassrooms", exception.Operation);
-        Assert.Same(expectedException, exception.InnerException);
-    }
+    #region GetClassroomByIdAsync
 
     [Fact]
-    public async Task GetClassroomByIdAsync_ReturnsClassroom_WhenFound()
+    public async Task GetClassroomByIdAsync_DelegatesToCrudService()
     {
         var id = Guid.NewGuid();
-        var classroom = new Classroom { Id = Guid.NewGuid(), Name = "Room 207" };
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByIdAsync(id))
-            .ReturnsAsync(classroom);
+        var classroom = new Classroom { Id = id, Name = "Room 207" };
+        _mockCrudService.Setup(s => s.GetByIdAsync(id)).ReturnsAsync(classroom);
 
         var result = await _service.GetClassroomByIdAsync(id);
 
         Assert.Same(classroom, result);
+        _mockCrudService.Verify(s => s.GetByIdAsync(id), Times.Once);
     }
 
     [Fact]
     public async Task GetClassroomByIdAsync_ThrowsEntityNotFoundException_WhenMissing()
     {
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync((Classroom?)null);
+        var id = Guid.NewGuid();
+        _mockCrudService.Setup(s => s.GetByIdAsync(id))
+            .ThrowsAsync(new EntityNotFoundException<Guid>("Classroom", id));
 
-        var exception = await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(() => _service.GetClassroomByIdAsync(Guid.NewGuid()));
-
-        Assert.Equal("Classroom", exception.EntityName);
-        Assert.NotEqual(Guid.Empty, exception.Key);
-    }
-
-    [Fact]
-    public async Task GetClassroomByIdAsync_WrapsUnexpectedFailures()
-    {
-        var expectedException = new InvalidOperationException("Lookup failed");
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByIdAsync(It.IsAny<Guid>()))
-            .ThrowsAsync(expectedException);
-
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.GetClassroomByIdAsync(Guid.NewGuid()));
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(
+            () => _service.GetClassroomByIdAsync(id));
 
         Assert.Equal("Classroom", exception.EntityName);
-        Assert.Contains("GetClassroomById:", exception.Operation);
-        Assert.Same(expectedException, exception.InnerException);
     }
 
-    [Fact]
-    public async Task GetClassroomByUuidAsync_ReturnsClassroom_WhenFound()
-    {
-        var classroomUuid = Guid.NewGuid();
-        var classroom = new Classroom { Id = classroomUuid, Name = "Room 207" };
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByUuidAsync(classroomUuid))
-            .ReturnsAsync(classroom);
+    #endregion
 
-        var result = await _service.GetClassroomByUuidAsync(classroomUuid);
+    #region GetClassroomByUuidAsync
+
+    [Fact]
+    public async Task GetClassroomByUuidAsync_DelegatesToCrudService()
+    {
+        var id = Guid.NewGuid();
+        var classroom = new Classroom { Id = id, Name = "Room 207" };
+        _mockCrudService.Setup(s => s.GetByIdAsync(id)).ReturnsAsync(classroom);
+
+        var result = await _service.GetClassroomByUuidAsync(id);
 
         Assert.Same(classroom, result);
+        _mockCrudService.Verify(s => s.GetByIdAsync(id), Times.Once);
+    }
+
+    #endregion
+
+    #region CreateClassroomAsync
+
+    [Fact]
+    public async Task CreateClassroomAsync_DelegatesToCrudService()
+    {
+        var dto = new CreateClassroom { Name = "Lab 1" };
+        var created = new Classroom { Id = Guid.NewGuid(), Name = "Lab 1" };
+        _mockCrudService.Setup(s => s.CreateAsync(dto)).ReturnsAsync(created);
+
+        var result = await _service.CreateClassroomAsync(dto);
+
+        Assert.Same(created, result);
+        _mockCrudService.Verify(s => s.CreateAsync(dto), Times.Once);
     }
 
     [Fact]
-    public async Task GetClassroomByUuidAsync_ThrowsEntityNotFoundException_WhenMissing()
+    public async Task CreateClassroomAsync_PropagatesValidationException()
     {
-        var classroomUuid = Guid.NewGuid();
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByUuidAsync(classroomUuid))
-            .ReturnsAsync((Classroom?)null);
+        var dto = new CreateClassroom { Name = "" };
+        _mockCrudService.Setup(s => s.CreateAsync(dto))
+            .ThrowsAsync(new ValidationException("Name is required"));
 
-        var exception = await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(() => _service.GetClassroomByUuidAsync(classroomUuid));
-
-        Assert.Equal("Classroom", exception.EntityName);
-        Assert.Equal(classroomUuid, exception.Key);
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
-    public async Task CreateClassroomAsync_BlankName_ThrowsValidationException(string? name)
-    {
-        var createClassroom = new CreateClassroom { Name = name! };
-
-        var exception = await Assert.ThrowsAsync<ValidationException>(() => _service.CreateClassroomAsync(createClassroom));
-
-        Assert.Equal("Classroom name is required", exception.Message);
+        await Assert.ThrowsAsync<ValidationException>(() => _service.CreateClassroomAsync(dto));
     }
 
     [Fact]
-    public async Task CreateClassroomAsync_DuplicateNamePreCheck_ThrowsEntityAlreadyExistsException()
+    public async Task CreateClassroomAsync_PropagatesEntityAlreadyExistsException()
     {
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByNameAsync("Room 101"))
-            .ReturnsAsync(new Classroom { Id = Guid.NewGuid(), Name = "Room 101" });
+        var dto = new CreateClassroom { Name = "Room 101" };
+        _mockCrudService.Setup(s => s.CreateAsync(dto))
+            .ThrowsAsync(new EntityAlreadyExistsException<string>("Classroom", "Name", "Room 101"));
 
         var exception = await Assert.ThrowsAsync<EntityAlreadyExistsException<string>>(
-            () => _service.CreateClassroomAsync(new CreateClassroom { Name = "Room 101" }));
+            () => _service.CreateClassroomAsync(dto));
 
-        Assert.Equal("Classroom", exception.EntityName);
-        Assert.Equal("Name", exception.IdentifierPropertyName);
         Assert.Equal("Room 101", exception.EntityIdentifier);
     }
 
+    #endregion
+
+    #region UpdateClassroomAsync
+
     [Fact]
-    public async Task CreateClassroomAsync_ValidInput_CreatesClassroom()
+    public async Task UpdateClassroomAsync_DelegatesToCrudService()
     {
-        Classroom? capturedClassroom = null;
-        var createdClassroom = new Classroom { Id = Guid.NewGuid(), Name = "Lab 1" };
+        var id = Guid.NewGuid();
+        var dto = new UpdateClassroom { Name = "Updated" };
+        var updated = new Classroom { Id = id, Name = "Updated" };
+        _mockCrudService.Setup(s => s.UpdateAsync(id, dto)).ReturnsAsync(updated);
 
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByNameAsync("Lab 1"))
-            .ReturnsAsync((Classroom?)null);
-        _mockClassroomRepository
-            .Setup(repository => repository.CreateClassroom(It.IsAny<Classroom>()))
-            .Callback<Classroom>(classroom => capturedClassroom = classroom)
-            .ReturnsAsync(createdClassroom);
-        _mockClassroomRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ReturnsAsync(1);
+        var result = await _service.UpdateClassroomAsync(id, dto);
 
-        var result = await _service.CreateClassroomAsync(new CreateClassroom { Name = "Lab 1" });
-
-        Assert.Same(createdClassroom, result);
-        Assert.NotNull(capturedClassroom);
-        Assert.Equal("Lab 1", capturedClassroom.Name);
-        _mockClassroomRepository.Verify(repository => repository.CreateClassroom(It.IsAny<Classroom>()), Times.Once);
-        _mockClassroomRepository.Verify(repository => repository.SaveChangesAsync(), Times.Once);
+        Assert.Same(updated, result);
+        _mockCrudService.Verify(s => s.UpdateAsync(id, dto), Times.Once);
     }
 
     [Fact]
-    public async Task CreateClassroomAsync_UniqueConstraintViolation_ThrowsEntityAlreadyExistsException()
+    public async Task UpdateClassroomAsync_PropagatesEntityNotFoundException()
     {
-        var dbUpdateException = new DbUpdateException(
-            "Duplicate",
-            new Exception("Cannot insert duplicate key row with unique index 'IX_Classrooms_Name'"));
+        var id = Guid.NewGuid();
+        var dto = new UpdateClassroom { Name = "Updated" };
+        _mockCrudService.Setup(s => s.UpdateAsync(id, dto))
+            .ThrowsAsync(new EntityNotFoundException<Guid>("Classroom", id));
 
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByNameAsync("Lab 1"))
-            .ReturnsAsync((Classroom?)null);
-        _mockClassroomRepository
-            .Setup(repository => repository.CreateClassroom(It.IsAny<Classroom>()))
-            .ThrowsAsync(dbUpdateException);
+        await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(
+            () => _service.UpdateClassroomAsync(id, dto));
+    }
 
-        var exception = await Assert.ThrowsAsync<EntityAlreadyExistsException<string>>(
-            () => _service.CreateClassroomAsync(new CreateClassroom { Name = "Lab 1" }));
+    #endregion
 
-        Assert.Equal("Classroom", exception.EntityName);
-        Assert.Equal("Name", exception.IdentifierPropertyName);
-        Assert.Equal("Lab 1", exception.EntityIdentifier);
+    #region UpdateClassroomByUuidAsync
+
+    [Fact]
+    public async Task UpdateClassroomByUuidAsync_DelegatesToCrudService()
+    {
+        var id = Guid.NewGuid();
+        var dto = new UpdateClassroom { Name = "Updated" };
+        var updated = new Classroom { Id = id, Name = "Updated" };
+        _mockCrudService.Setup(s => s.UpdateAsync(id, dto)).ReturnsAsync(updated);
+
+        var result = await _service.UpdateClassroomByUuidAsync(id, dto);
+
+        Assert.Same(updated, result);
+        _mockCrudService.Verify(s => s.UpdateAsync(id, dto), Times.Once);
+    }
+
+    #endregion
+
+    #region DeleteClassroomAsync
+
+    [Fact]
+    public async Task DeleteClassroomAsync_DelegatesToCrudService()
+    {
+        var id = Guid.NewGuid();
+        _mockCrudService.Setup(s => s.DeleteAsync(id)).Returns(Task.CompletedTask);
+
+        await _service.DeleteClassroomAsync(id);
+
+        _mockCrudService.Verify(s => s.DeleteAsync(id), Times.Once);
     }
 
     [Fact]
-    public async Task CreateClassroomAsync_WrapsUnexpectedFailures()
+    public async Task DeleteClassroomAsync_PropagatesEntityNotFoundException()
     {
-        var expectedException = new InvalidOperationException("Create failed");
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByNameAsync("Lab 1"))
-            .ThrowsAsync(expectedException);
+        var id = Guid.NewGuid();
+        _mockCrudService.Setup(s => s.DeleteAsync(id))
+            .ThrowsAsync(new EntityNotFoundException<Guid>("Classroom", id));
 
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(
-            () => _service.CreateClassroomAsync(new CreateClassroom { Name = "Lab 1" }));
-
-        Assert.Equal("Classroom", exception.EntityName);
-        Assert.Equal("CreateClassroom", exception.Operation);
-        Assert.Same(expectedException, exception.InnerException);
+        await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(
+            () => _service.DeleteClassroomAsync(id));
     }
+
+    #endregion
+
+    #region DeleteClassroomByUuidAsync
 
     [Fact]
-    public async Task UpdateClassroomAsync_NotFound_ThrowsEntityNotFoundException()
+    public async Task DeleteClassroomByUuidAsync_DelegatesToCrudService()
     {
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync((Classroom?)null);
+        var id = Guid.NewGuid();
+        _mockCrudService.Setup(s => s.DeleteAsync(id)).Returns(Task.CompletedTask);
 
-        var exception = await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(
-            () => _service.UpdateClassroomAsync(Guid.NewGuid(), new UpdateClassroom { Name = "Updated" }));
+        await _service.DeleteClassroomByUuidAsync(id);
 
-        Assert.Equal("Classroom", exception.EntityName);
-        Assert.NotEqual(Guid.Empty, exception.Key);
+        _mockCrudService.Verify(s => s.DeleteAsync(id), Times.Once);
     }
 
-    [Fact]
-    public async Task UpdateClassroomAsync_ValidInput_UpdatesClassroom()
-    {
-        var existingClassroom = new Classroom { Id = Guid.NewGuid(), Name = "Old" };
-        Classroom? updatedEntity = null;
+    #endregion
 
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(existingClassroom);
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByNameAsync("New"))
-            .ReturnsAsync((Classroom?)null);
-        _mockClassroomRepository
-            .Setup(repository => repository.UpdateClassroomAsync(It.IsAny<Classroom>()))
-            .Callback<Classroom>(classroom => updatedEntity = classroom)
-            .ReturnsAsync((Classroom classroom) => classroom);
-        _mockClassroomRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ReturnsAsync(1);
-
-        var result = await _service.UpdateClassroomAsync(Guid.NewGuid(), new UpdateClassroom { Name = "New" });
-
-        Assert.Equal("New", result.Name);
-        Assert.NotNull(updatedEntity);
-        Assert.Equal("New", updatedEntity.Name);
-        _mockClassroomRepository.Verify(repository => repository.SaveChangesAsync(), Times.Once);
-    }
-
-    [Fact]
-    public async Task UpdateClassroomAsync_EmptyName_LeavesNameUnchanged()
-    {
-        var existingClassroom = new Classroom { Id = Guid.NewGuid(), Name = "Old" };
-
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(existingClassroom);
-        _mockClassroomRepository
-            .Setup(repository => repository.UpdateClassroomAsync(It.IsAny<Classroom>()))
-            .ReturnsAsync((Classroom classroom) => classroom);
-        _mockClassroomRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ReturnsAsync(1);
-
-        var result = await _service.UpdateClassroomAsync(Guid.NewGuid(), new UpdateClassroom { Name = string.Empty });
-
-        Assert.Equal("Old", result.Name);
-        _mockClassroomRepository.Verify(repository => repository.GetClassroomByNameAsync(It.IsAny<string>()), Times.Never);
-    }
-
-    [Fact]
-    public async Task UpdateClassroomAsync_DuplicateName_ThrowsEntityAlreadyExistsException()
-    {
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(new Classroom { Id = Guid.NewGuid(), Name = "Old" });
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByNameAsync("Taken"))
-            .ReturnsAsync(new Classroom { Id = Guid.NewGuid(), Name = "Taken" });
-
-        var exception = await Assert.ThrowsAsync<EntityAlreadyExistsException<string>>(
-            () => _service.UpdateClassroomAsync(Guid.NewGuid(), new UpdateClassroom { Name = "Taken" }));
-
-        Assert.Equal("Classroom", exception.EntityName);
-        Assert.Equal("Name", exception.IdentifierPropertyName);
-        Assert.Equal("Taken", exception.EntityIdentifier);
-    }
-
-    [Fact]
-    public async Task UpdateClassroomAsync_UniqueConstraintViolation_ThrowsEntityAlreadyExistsException()
-    {
-        var dbUpdateException = new DbUpdateException(
-            "Duplicate",
-            new Exception("duplicate key value violates unique constraint \"IX_Classrooms_Name\""));
-
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(new Classroom { Id = Guid.NewGuid(), Name = "Old" });
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByNameAsync("New"))
-            .ReturnsAsync((Classroom?)null);
-        _mockClassroomRepository
-            .Setup(repository => repository.UpdateClassroomAsync(It.IsAny<Classroom>()))
-            .ThrowsAsync(dbUpdateException);
-
-        var exception = await Assert.ThrowsAsync<EntityAlreadyExistsException<string>>(
-            () => _service.UpdateClassroomAsync(Guid.NewGuid(), new UpdateClassroom { Name = "New" }));
-
-        Assert.Equal("Classroom", exception.EntityName);
-        Assert.Equal("Name", exception.IdentifierPropertyName);
-        Assert.Equal("New", exception.EntityIdentifier);
-    }
-
-    [Fact]
-    public async Task UpdateClassroomAsync_NoRowsAffected_ThrowsEntityServiceException()
-    {
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(new Classroom { Id = Guid.NewGuid(), Name = "Old" });
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByNameAsync("New"))
-            .ReturnsAsync((Classroom?)null);
-        _mockClassroomRepository
-            .Setup(repository => repository.UpdateClassroomAsync(It.IsAny<Classroom>()))
-            .ReturnsAsync((Classroom classroom) => classroom);
-        _mockClassroomRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ReturnsAsync(0);
-
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(
-            () => _service.UpdateClassroomAsync(Guid.NewGuid(), new UpdateClassroom { Name = "New" }));
-
-        Assert.Equal("Classroom", exception.EntityName);
-        Assert.Contains("UpdateClassroom:", exception.Operation);
-        Assert.Contains("updated by another process", exception.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public async Task UpdateClassroomAsync_WrapsUnexpectedFailures()
-    {
-        var expectedException = new InvalidOperationException("Update failed");
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByIdAsync(It.IsAny<Guid>()))
-            .ThrowsAsync(expectedException);
-
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(
-            () => _service.UpdateClassroomAsync(Guid.NewGuid(), new UpdateClassroom { Name = "New" }));
-
-        Assert.Equal("Classroom", exception.EntityName);
-        Assert.Contains("UpdateClassroom:", exception.Operation);
-        Assert.Same(expectedException, exception.InnerException);
-    }
-
-    [Fact]
-    public async Task DeleteClassroomAsync_NotFound_ThrowsEntityNotFoundException()
-    {
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync((Classroom?)null);
-
-        var exception = await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(() => _service.DeleteClassroomAsync(Guid.NewGuid()));
-
-        Assert.Equal("Classroom", exception.EntityName);
-        Assert.NotEqual(Guid.Empty, exception.Key);
-    }
-
-    [Fact]
-    public async Task DeleteClassroomAsync_Success_DeletesClassroom()
-    {
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(new Classroom { Id = Guid.NewGuid(), Name = "Room 5" });
-        _mockClassroomRepository
-            .Setup(repository => repository.DeleteClassroomAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(true);
-        _mockClassroomRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ReturnsAsync(1);
-
-        await _service.DeleteClassroomAsync(Guid.NewGuid());
-
-        _mockClassroomRepository.Verify(repository => repository.DeleteClassroomAsync(It.IsAny<Guid>()), Times.Once);
-        _mockClassroomRepository.Verify(repository => repository.SaveChangesAsync(), Times.Once);
-    }
-
-    [Fact]
-    public async Task DeleteClassroomAsync_DeleteReturnsFalse_ThrowsEntityServiceException()
-    {
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(new Classroom { Id = Guid.NewGuid(), Name = "Room 5" });
-        _mockClassroomRepository
-            .Setup(repository => repository.DeleteClassroomAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(false);
-
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteClassroomAsync(Guid.NewGuid()));
-
-        Assert.Equal("Classroom", exception.EntityName);
-        Assert.Contains("DeleteClassroom:", exception.Operation);
-    }
-
-    [Fact]
-    public async Task DeleteClassroomAsync_NoRowsAffected_ThrowsEntityServiceException()
-    {
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(new Classroom { Id = Guid.NewGuid(), Name = "Room 5" });
-        _mockClassroomRepository
-            .Setup(repository => repository.DeleteClassroomAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(true);
-        _mockClassroomRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ReturnsAsync(0);
-
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteClassroomAsync(Guid.NewGuid()));
-
-        Assert.Equal("Classroom", exception.EntityName);
-        Assert.Contains("DeleteClassroom:", exception.Operation);
-        Assert.Contains("deleted by another process", exception.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Theory]
-    [InlineData("The DELETE statement conflicted with the REFERENCE constraint \"FK_Sessions_Classrooms_ActualRoomId\"", "sessions")]
-    [InlineData("The DELETE statement conflicted with the REFERENCE constraint \"FK_Schedules_Classrooms\"", "schedules")]
-    [InlineData("23503: update or delete on table \"Classrooms\" violates foreign key constraint \"FK_Unknown\"", "dependencies")]
-    public async Task DeleteClassroomAsync_ForeignKeyViolation_ThrowsEntityConflictException(string innerMessage, string expectedConflictType)
-    {
-        var dbUpdateException = new DbUpdateException("Delete failed", new Exception(innerMessage));
-
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(new Classroom { Id = Guid.NewGuid(), Name = "Room 5" });
-        _mockClassroomRepository
-            .Setup(repository => repository.DeleteClassroomAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(true);
-        _mockClassroomRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ThrowsAsync(dbUpdateException);
-
-        var exception = await Assert.ThrowsAsync<EntityConflictException>(() => _service.DeleteClassroomAsync(Guid.NewGuid()));
-
-        Assert.Equal("Classroom", exception.EntityName);
-        Assert.Equal(expectedConflictType, exception.ConflictType);
-    }
-
-    [Fact]
-    public async Task DeleteClassroomAsync_WrapsUnexpectedFailures()
-    {
-        var expectedException = new InvalidOperationException("Delete failed");
-        _mockClassroomRepository
-            .Setup(repository => repository.GetClassroomByIdAsync(It.IsAny<Guid>()))
-            .ThrowsAsync(expectedException);
-
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteClassroomAsync(Guid.NewGuid()));
-
-        Assert.Equal("Classroom", exception.EntityName);
-        Assert.Contains("DeleteClassroom:", exception.Operation);
-        Assert.Same(expectedException, exception.InnerException);
-    }
+    #region Dependency Check Operations
 
     [Fact]
     public async Task HasSchedulesInClassroomAsync_ReturnsRepositoryResult()
@@ -542,4 +275,6 @@ public class ClassroomServiceTest
         Assert.Contains("HasSessionsInClassroom:", exception.Operation);
         Assert.Same(expectedException, exception.InnerException);
     }
+
+    #endregion
 }

--- a/attendance.testproject/Services_Testing/CourseServiceTest.cs
+++ b/attendance.testproject/Services_Testing/CourseServiceTest.cs
@@ -5,7 +5,7 @@ using attendance_monitoring.IRepository;
 using attendance_monitoring.IServices;
 using attendance_monitoring.Models.DTO.Request;
 using attendance_monitoring.Services;
-using Microsoft.EntityFrameworkCore;
+using attendance_monitoring.Services.Crud;
 using Microsoft.Extensions.Logging;
 using Moq;
 
@@ -14,6 +14,7 @@ namespace attendance.testproject.Services_Testing;
 public class CourseServiceTest
 {
     private readonly Mock<ICourseRepository> _mockCourseRepository;
+    private readonly Mock<ICrudService<Course, CreateCourse, UpdateCourse>> _mockCrudService;
     private readonly Mock<IUserContextService> _mockUserContextService;
     private readonly Mock<ILogger<CourseService>> _mockLogger;
     private readonly CourseService _service;
@@ -22,9 +23,11 @@ public class CourseServiceTest
     public CourseServiceTest()
     {
         _mockCourseRepository = new Mock<ICourseRepository>();
+        _mockCrudService = new Mock<ICrudService<Course, CreateCourse, UpdateCourse>>();
         _mockUserContextService = new Mock<IUserContextService>();
         _mockLogger = new Mock<ILogger<CourseService>>();
-        _service = new CourseService(_mockCourseRepository.Object, _mockUserContextService.Object, _mockLogger.Object);
+        _service = new CourseService(_mockCrudService.Object, _mockCourseRepository.Object,
+            _mockUserContextService.Object, _mockLogger.Object);
 
         _testUserPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new[]
         {
@@ -33,443 +36,196 @@ public class CourseServiceTest
         }, "TestAuth"));
     }
 
-    [Fact]
-    public void Constructor_NullRepository_ThrowsArgumentNullException()
-    {
-        var exception = Assert.Throws<ArgumentNullException>(() => new CourseService(null!, _mockUserContextService.Object, _mockLogger.Object));
-
-        Assert.Equal("courseRepository", exception.ParamName);
-    }
+    #region Read Operations
 
     [Fact]
-    public void Constructor_NullUserContextService_ThrowsArgumentNullException()
+    public async Task GetAllCoursesAsync_DelegatesToCrudService()
     {
-        var exception = Assert.Throws<ArgumentNullException>(() => new CourseService(_mockCourseRepository.Object, null!, _mockLogger.Object));
-
-        Assert.Equal("userContextService", exception.ParamName);
-    }
-
-    [Fact]
-    public void Constructor_NullLogger_ThrowsArgumentNullException()
-    {
-        var exception = Assert.Throws<ArgumentNullException>(() => new CourseService(_mockCourseRepository.Object, _mockUserContextService.Object, null!));
-
-        Assert.Equal("logger", exception.ParamName);
-    }
-
-    [Fact]
-    public async Task GetAllCoursesAsync_ReturnsMaterializedCourses()
-    {
-        _mockCourseRepository
-            .Setup(repository => repository.GetAllCoursesAsync())
-            .ReturnsAsync(new List<Course>
-            {
-                new() { Id = Guid.NewGuid(), Name = "Math" },
-                new() { Id = Guid.NewGuid(), Name = "Science" },
-            });
+        var courses = new List<Course>
+        {
+            new() { Id = Guid.NewGuid(), Name = "Math" },
+            new() { Id = Guid.NewGuid(), Name = "Science" },
+        };
+        _mockCrudService.Setup(s => s.GetAllAsync()).ReturnsAsync(courses);
 
         var result = await _service.GetAllCoursesAsync();
 
-        var materialized = Assert.IsType<List<Course>>(result);
-        Assert.Collection(materialized,
-            course => Assert.Equal("Math", course.Name),
-            course => Assert.Equal("Science", course.Name));
+        Assert.Equal(2, result.Count);
+        _mockCrudService.Verify(s => s.GetAllAsync(), Times.Once);
     }
 
     [Fact]
-    public async Task GetAllCoursesAsync_WrapsUnexpectedFailures()
+    public async Task GetCourseByIdAsync_DelegatesToCrudService()
     {
-        var expectedException = new InvalidOperationException("Lookup failed");
-        _mockCourseRepository
-            .Setup(repository => repository.GetAllCoursesAsync())
-            .ThrowsAsync(expectedException);
+        var id = Guid.NewGuid();
+        var course = new Course { Id = id, Name = "Physics" };
+        _mockCrudService.Setup(s => s.GetByIdAsync(id)).ReturnsAsync(course);
 
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.GetAllCoursesAsync());
-
-        Assert.Equal("Course", exception.EntityName);
-        Assert.Equal("GetAllCourses", exception.Operation);
-        Assert.Same(expectedException, exception.InnerException);
-    }
-
-    [Fact]
-    public async Task GetCourseByIdAsync_ReturnsCourse_WhenFound()
-    {
-        var course = new Course { Id = Guid.NewGuid(), Name = "Physics" };
-        _mockCourseRepository
-            .Setup(repository => repository.GetCourseByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(course);
-
-        var result = await _service.GetCourseByIdAsync(Guid.NewGuid());
+        var result = await _service.GetCourseByIdAsync(id);
 
         Assert.Same(course, result);
     }
 
     [Fact]
-    public async Task GetCourseByIdAsync_ThrowsEntityNotFoundException_WhenMissing()
+    public async Task GetCourseByUuidAsync_DelegatesToCrudService()
     {
-        _mockCourseRepository
-            .Setup(repository => repository.GetCourseByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync((Course?)null);
+        var id = Guid.NewGuid();
+        var course = new Course { Id = id, Name = "Physics" };
+        _mockCrudService.Setup(s => s.GetByIdAsync(id)).ReturnsAsync(course);
 
-        var exception = await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(() => _service.GetCourseByIdAsync(Guid.NewGuid()));
-
-        Assert.Equal("Course", exception.EntityName);
-        Assert.NotEqual(Guid.Empty, exception.Key);
-    }
-
-    [Fact]
-    public async Task GetCourseByIdAsync_WrapsUnexpectedFailures()
-    {
-        var expectedException = new InvalidOperationException("Lookup failed");
-        _mockCourseRepository
-            .Setup(repository => repository.GetCourseByIdAsync(It.IsAny<Guid>()))
-            .ThrowsAsync(expectedException);
-
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.GetCourseByIdAsync(Guid.NewGuid()));
-
-        Assert.Equal("Course", exception.EntityName);
-        Assert.Contains("GetCourseById:", exception.Operation);
-        Assert.Same(expectedException, exception.InnerException);
-    }
-
-    [Fact]
-    public async Task GetCourseByUuidAsync_ReturnsCourse_WhenFound()
-    {
-        var courseUuid = Guid.NewGuid();
-        var course = new Course { Id = courseUuid, Name = "Physics" };
-        _mockCourseRepository
-            .Setup(repository => repository.GetCourseByUuidAsync(courseUuid))
-            .ReturnsAsync(course);
-
-        var result = await _service.GetCourseByUuidAsync(courseUuid);
+        var result = await _service.GetCourseByUuidAsync(id);
 
         Assert.Same(course, result);
     }
 
-    [Fact]
-    public async Task GetCourseByUuidAsync_ThrowsEntityNotFoundException_WhenMissing()
-    {
-        var courseUuid = Guid.NewGuid();
-        _mockCourseRepository
-            .Setup(repository => repository.GetCourseByUuidAsync(courseUuid))
-            .ReturnsAsync((Course?)null);
+    #endregion
 
-        var exception = await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(() => _service.GetCourseByUuidAsync(courseUuid));
-
-        Assert.Equal("Course", exception.EntityName);
-        Assert.Equal(courseUuid, exception.Key);
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
-    public async Task CreateCourseAsync_BlankName_ThrowsEntityServiceException(string? name)
-    {
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(
-            () => _service.CreateCourseAsync(new CreateCourse { Name = name! }, _testUserPrincipal));
-
-        Assert.Equal("Course", exception.EntityName);
-        Assert.Equal("CreateCourse", exception.Operation);
-        Assert.Contains("Course name is required", exception.Message, StringComparison.OrdinalIgnoreCase);
-    }
+    #region Create Operations
 
     [Fact]
     public async Task CreateCourseAsync_MissingUserId_ThrowsEntityServiceException()
     {
         _mockUserContextService
-            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .Setup(s => s.GetUserIdAsync(_testUserPrincipal))
             .ReturnsAsync((string?)null);
 
         var exception = await Assert.ThrowsAsync<EntityServiceException>(
             () => _service.CreateCourseAsync(new CreateCourse { Name = "Physics" }, _testUserPrincipal));
 
         Assert.Equal("Course", exception.EntityName);
-        Assert.Equal("CreateCourse", exception.Operation);
         Assert.Contains("User ID not found", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public async Task CreateCourseAsync_ValidInput_CreatesCourse()
+    public async Task CreateCourseAsync_ValidInput_DelegatesToCrudService()
     {
-        Course? capturedCourse = null;
-        var createdCourse = new Course { Id = Guid.NewGuid(), Name = "Physics" };
+        var dto = new CreateCourse { Name = "Physics" };
+        var created = new Course { Id = Guid.NewGuid(), Name = "Physics" };
 
         _mockUserContextService
-            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .Setup(s => s.GetUserIdAsync(_testUserPrincipal))
             .ReturnsAsync("user-1");
-        _mockCourseRepository
-            .Setup(repository => repository.CreateCourse(It.IsAny<Course>()))
-            .Callback<Course>(course => capturedCourse = course)
-            .ReturnsAsync(createdCourse);
-        _mockCourseRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ReturnsAsync(1);
+        _mockCrudService.Setup(s => s.CreateAsync(dto)).ReturnsAsync(created);
 
-        var result = await _service.CreateCourseAsync(new CreateCourse { Name = "Physics" }, _testUserPrincipal);
+        var result = await _service.CreateCourseAsync(dto, _testUserPrincipal);
 
-        Assert.Same(createdCourse, result);
-        Assert.NotNull(capturedCourse);
-        Assert.Equal("Physics", capturedCourse.Name);
-        _mockCourseRepository.Verify(repository => repository.CreateCourse(It.IsAny<Course>()), Times.Once);
-        _mockCourseRepository.Verify(repository => repository.SaveChangesAsync(), Times.Once);
+        Assert.Same(created, result);
+        _mockCrudService.Verify(s => s.CreateAsync(dto), Times.Once);
     }
 
-    [Fact]
-    public async Task CreateCourseAsync_WrapsUnexpectedFailures()
-    {
-        var expectedException = new InvalidOperationException("Create failed");
-        _mockUserContextService
-            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
-            .ReturnsAsync("user-1");
-        _mockCourseRepository
-            .Setup(repository => repository.CreateCourse(It.IsAny<Course>()))
-            .ThrowsAsync(expectedException);
+    #endregion
 
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(
-            () => _service.CreateCourseAsync(new CreateCourse { Name = "Physics" }, _testUserPrincipal));
-
-        Assert.Equal("Course", exception.EntityName);
-        Assert.Equal("CreateCourse", exception.Operation);
-        Assert.Same(expectedException, exception.InnerException);
-    }
-
-    [Fact]
-    public async Task UpdateCourseAsync_NullUpdateDto_ThrowsEntityServiceException()
-    {
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(
-            () => _service.UpdateCourseAsync(Guid.NewGuid(), null!, _testUserPrincipal));
-
-        Assert.Equal("Course", exception.EntityName);
-        Assert.Contains("UpdateCourse:", exception.Operation);
-        Assert.Contains("required", exception.Message, StringComparison.OrdinalIgnoreCase);
-    }
+    #region Update Operations
 
     [Fact]
     public async Task UpdateCourseAsync_MissingUserId_ThrowsEntityServiceException()
     {
         _mockUserContextService
-            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .Setup(s => s.GetUserIdAsync(_testUserPrincipal))
             .ReturnsAsync(string.Empty);
 
         var exception = await Assert.ThrowsAsync<EntityServiceException>(
             () => _service.UpdateCourseAsync(Guid.NewGuid(), new UpdateCourse { Name = "New" }, _testUserPrincipal));
 
         Assert.Equal("Course", exception.EntityName);
-        Assert.Contains("UpdateCourse:", exception.Operation);
         Assert.Contains("User ID not found", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public async Task UpdateCourseAsync_NotFound_ThrowsEntityNotFoundException()
+    public async Task UpdateCourseAsync_ValidInput_DelegatesToCrudService()
     {
+        var id = Guid.NewGuid();
+        var dto = new UpdateCourse { Name = "New" };
+        var updated = new Course { Id = id, Name = "New" };
+
         _mockUserContextService
-            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .Setup(s => s.GetUserIdAsync(_testUserPrincipal))
             .ReturnsAsync("user-1");
-        _mockCourseRepository
-            .Setup(repository => repository.GetCourseByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync((Course?)null);
+        _mockCrudService.Setup(s => s.UpdateAsync(id, dto)).ReturnsAsync(updated);
 
-        var exception = await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(
-            () => _service.UpdateCourseAsync(Guid.NewGuid(), new UpdateCourse { Name = "New" }, _testUserPrincipal));
+        var result = await _service.UpdateCourseAsync(id, dto, _testUserPrincipal);
 
-        Assert.Equal("Course", exception.EntityName);
-        Assert.NotEqual(Guid.Empty, exception.Key);
+        Assert.Same(updated, result);
+        _mockCrudService.Verify(s => s.UpdateAsync(id, dto), Times.Once);
     }
 
     [Fact]
-    public async Task UpdateCourseAsync_ValidInput_UpdatesCourse()
+    public async Task UpdateCourseByUuidAsync_DelegatesToCrudService()
     {
-        var existingCourse = new Course { Id = Guid.NewGuid(), Name = "Old" };
+        var id = Guid.NewGuid();
+        var dto = new UpdateCourse { Name = "New" };
+        var updated = new Course { Id = id, Name = "New" };
 
         _mockUserContextService
-            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .Setup(s => s.GetUserIdAsync(_testUserPrincipal))
             .ReturnsAsync("user-1");
-        _mockCourseRepository
-            .Setup(repository => repository.GetCourseByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(existingCourse);
-        _mockCourseRepository
-            .Setup(repository => repository.UpdateCourseAsync(It.IsAny<Course>()))
-            .ReturnsAsync((Course course) => course);
-        _mockCourseRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ReturnsAsync(1);
+        _mockCrudService.Setup(s => s.UpdateAsync(id, dto)).ReturnsAsync(updated);
 
-        var result = await _service.UpdateCourseAsync(Guid.NewGuid(), new UpdateCourse { Name = "New" }, _testUserPrincipal);
+        var result = await _service.UpdateCourseByUuidAsync(id, dto, _testUserPrincipal);
 
-        Assert.Equal("New", result.Name);
-        _mockCourseRepository.Verify(repository => repository.UpdateCourseAsync(It.IsAny<Course>()), Times.Once);
-        _mockCourseRepository.Verify(repository => repository.SaveChangesAsync(), Times.Once);
+        Assert.Same(updated, result);
     }
 
-    [Fact]
-    public async Task UpdateCourseAsync_EmptyName_LeavesCourseNameUnchanged()
-    {
-        var existingCourse = new Course { Id = Guid.NewGuid(), Name = "Old" };
+    #endregion
 
-        _mockUserContextService
-            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
-            .ReturnsAsync("user-1");
-        _mockCourseRepository
-            .Setup(repository => repository.GetCourseByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(existingCourse);
-        _mockCourseRepository
-            .Setup(repository => repository.UpdateCourseAsync(It.IsAny<Course>()))
-            .ReturnsAsync((Course course) => course);
-        _mockCourseRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ReturnsAsync(1);
-
-        var result = await _service.UpdateCourseAsync(Guid.NewGuid(), new UpdateCourse { Name = string.Empty }, _testUserPrincipal);
-
-        Assert.Equal("Old", result.Name);
-    }
-
-    [Fact]
-    public async Task UpdateCourseAsync_WrapsUnexpectedFailures()
-    {
-        var expectedException = new InvalidOperationException("Update failed");
-        _mockUserContextService
-            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
-            .ReturnsAsync("user-1");
-        _mockCourseRepository
-            .Setup(repository => repository.GetCourseByIdAsync(It.IsAny<Guid>()))
-            .ThrowsAsync(expectedException);
-
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(
-            () => _service.UpdateCourseAsync(Guid.NewGuid(), new UpdateCourse { Name = "New" }, _testUserPrincipal));
-
-        Assert.Equal("Course", exception.EntityName);
-        Assert.Contains("UpdateCourse:", exception.Operation);
-        Assert.Same(expectedException, exception.InnerException);
-    }
+    #region Delete Operations
 
     [Fact]
     public async Task DeleteCourseAsync_MissingUserId_ThrowsEntityServiceException()
     {
         _mockUserContextService
-            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .Setup(s => s.GetUserIdAsync(_testUserPrincipal))
             .ReturnsAsync((string?)null);
 
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteCourseAsync(Guid.NewGuid(), _testUserPrincipal));
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.DeleteCourseAsync(Guid.NewGuid(), _testUserPrincipal));
 
         Assert.Equal("Course", exception.EntityName);
-        Assert.Contains("DeleteCourse:", exception.Operation);
         Assert.Contains("User ID not found", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public async Task DeleteCourseAsync_NotFound_ThrowsEntityNotFoundException()
+    public async Task DeleteCourseAsync_DelegatesToCrudService()
     {
+        var id = Guid.NewGuid();
+
         _mockUserContextService
-            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .Setup(s => s.GetUserIdAsync(_testUserPrincipal))
             .ReturnsAsync("user-1");
-        _mockCourseRepository
-            .Setup(repository => repository.GetCourseByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync((Course?)null);
+        _mockCrudService.Setup(s => s.DeleteAsync(id)).Returns(Task.CompletedTask);
 
-        var exception = await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(() => _service.DeleteCourseAsync(Guid.NewGuid(), _testUserPrincipal));
+        await _service.DeleteCourseAsync(id, _testUserPrincipal);
 
-        Assert.Equal("Course", exception.EntityName);
-        Assert.NotEqual(Guid.Empty, exception.Key);
+        _mockCrudService.Verify(s => s.DeleteAsync(id), Times.Once);
     }
 
     [Fact]
-    public async Task DeleteCourseAsync_Success_DeletesCourse()
+    public async Task DeleteCourseByUuidAsync_DelegatesToCrudService()
     {
-        _mockUserContextService
-            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
-            .ReturnsAsync("user-1");
-        _mockCourseRepository
-            .Setup(repository => repository.GetCourseByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(new Course { Id = Guid.NewGuid(), Name = "Biology" });
-        _mockCourseRepository
-            .Setup(repository => repository.DeleteCourseAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(true);
-        _mockCourseRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ReturnsAsync(1);
-
-        await _service.DeleteCourseAsync(Guid.NewGuid(), _testUserPrincipal);
-
-        _mockCourseRepository.Verify(repository => repository.DeleteCourseAsync(It.IsAny<Guid>()), Times.Once);
-        _mockCourseRepository.Verify(repository => repository.SaveChangesAsync(), Times.Once);
-    }
-
-    [Fact]
-    public async Task DeleteCourseAsync_DeleteReturnsFalse_ThrowsEntityServiceException()
-    {
-        _mockUserContextService
-            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
-            .ReturnsAsync("user-1");
-        _mockCourseRepository
-            .Setup(repository => repository.GetCourseByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(new Course { Id = Guid.NewGuid(), Name = "Biology" });
-        _mockCourseRepository
-            .Setup(repository => repository.DeleteCourseAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(false);
-
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteCourseAsync(Guid.NewGuid(), _testUserPrincipal));
-
-        Assert.Equal("Course", exception.EntityName);
-        Assert.Contains("DeleteCourse:", exception.Operation);
-        Assert.Contains("Failed to delete course", exception.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Theory]
-    [InlineData("The DELETE statement conflicted with the REFERENCE constraint \"FK_Sections_Courses\"", "sections assigned")]
-    [InlineData("23503: update or delete on table \"Courses\" violates foreign key constraint \"FK_Unknown\"", "dependencies that prevent deletion")]
-    public async Task DeleteCourseAsync_ForeignKeyViolation_ThrowsEntityConflictException(string innerMessage, string expectedMessagePart)
-    {
-        var dbUpdateException = new DbUpdateException("Delete failed", new Exception(innerMessage));
+        var id = Guid.NewGuid();
 
         _mockUserContextService
-            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
+            .Setup(s => s.GetUserIdAsync(_testUserPrincipal))
             .ReturnsAsync("user-1");
-        _mockCourseRepository
-            .Setup(repository => repository.GetCourseByIdAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(new Course { Id = Guid.NewGuid(), Name = "Biology" });
-        _mockCourseRepository
-            .Setup(repository => repository.DeleteCourseAsync(It.IsAny<Guid>()))
-            .ReturnsAsync(true);
-        _mockCourseRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ThrowsAsync(dbUpdateException);
+        _mockCrudService.Setup(s => s.DeleteAsync(id)).Returns(Task.CompletedTask);
 
-        var exception = await Assert.ThrowsAsync<EntityConflictException>(() => _service.DeleteCourseAsync(Guid.NewGuid(), _testUserPrincipal));
+        await _service.DeleteCourseByUuidAsync(id, _testUserPrincipal);
 
-        Assert.Equal("Course", exception.EntityName);
-        Assert.Equal("sections", exception.ConflictType);
-        Assert.Contains(expectedMessagePart, exception.Message, StringComparison.OrdinalIgnoreCase);
+        _mockCrudService.Verify(s => s.DeleteAsync(id), Times.Once);
     }
 
-    [Fact]
-    public async Task DeleteCourseAsync_WrapsUnexpectedFailures()
-    {
-        var expectedException = new InvalidOperationException("Delete failed");
-        _mockUserContextService
-            .Setup(service => service.GetUserIdAsync(_testUserPrincipal))
-            .ReturnsAsync("user-1");
-        _mockCourseRepository
-            .Setup(repository => repository.GetCourseByIdAsync(It.IsAny<Guid>()))
-            .ThrowsAsync(expectedException);
+    #endregion
 
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteCourseAsync(Guid.NewGuid(), _testUserPrincipal));
-
-        Assert.Equal("Course", exception.EntityName);
-        Assert.Contains("DeleteCourse:", exception.Operation);
-        Assert.Same(expectedException, exception.InnerException);
-    }
+    #region Dependency Check Operations
 
     [Fact]
     public async Task HasSectionsInCourseAsync_ReturnsRepositoryResult()
     {
-        var courseId = Guid.NewGuid();
         _mockCourseRepository
-            .Setup(repository => repository.HasSectionsInCourseAsync(courseId))
+            .Setup(r => r.HasSectionsInCourseAsync(It.IsAny<Guid>()))
             .ReturnsAsync(true);
 
-        var result = await _service.HasSectionsInCourseAsync(courseId);
+        var result = await _service.HasSectionsInCourseAsync(Guid.NewGuid());
 
         Assert.True(result);
     }
@@ -477,16 +233,18 @@ public class CourseServiceTest
     [Fact]
     public async Task HasSectionsInCourseAsync_WrapsUnexpectedFailures()
     {
-        var courseId = Guid.NewGuid();
         var expectedException = new InvalidOperationException("Lookup failed");
         _mockCourseRepository
-            .Setup(repository => repository.HasSectionsInCourseAsync(courseId))
+            .Setup(r => r.HasSectionsInCourseAsync(It.IsAny<Guid>()))
             .ThrowsAsync(expectedException);
 
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.HasSectionsInCourseAsync(courseId));
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.HasSectionsInCourseAsync(Guid.NewGuid()));
 
         Assert.Equal("Course", exception.EntityName);
-        Assert.Equal($"HasSectionsInCourse: {courseId}", exception.Operation);
+        Assert.Contains("HasSectionsInCourse:", exception.Operation);
         Assert.Same(expectedException, exception.InnerException);
     }
+
+    #endregion
 }

--- a/attendance.testproject/Services_Testing/SectionServiceTest.cs
+++ b/attendance.testproject/Services_Testing/SectionServiceTest.cs
@@ -1,35 +1,60 @@
+using attendance_monitoring.Classes;
 using attendance_monitoring.Exceptions;
 using attendance_monitoring.IRepository;
-using attendance_monitoring.Classes;
+using attendance_monitoring.Models.DTO.Response;
 using attendance_monitoring.Services;
-using Microsoft.EntityFrameworkCore;
+using attendance_monitoring.Services.Crud;
 using Microsoft.Extensions.Logging;
+using Moq;
 
 namespace attendance.testproject.Services_Testing;
 
 public class SectionServiceTest
 {
     private readonly Mock<ISectionRepository> _mockSectionRepository;
+    private readonly Mock<ICrudService<Section, Section, Section>> _mockCrudService;
     private readonly Mock<ILogger<SectionService>> _mockLogger;
     private readonly SectionService _service;
 
     public SectionServiceTest()
     {
         _mockSectionRepository = new Mock<ISectionRepository>();
+        _mockCrudService = new Mock<ICrudService<Section, Section, Section>>();
         _mockLogger = new Mock<ILogger<SectionService>>();
-        _service = new SectionService(_mockSectionRepository.Object, _mockLogger.Object);
+        _service = new SectionService(_mockCrudService.Object, _mockSectionRepository.Object, _mockLogger.Object);
+    }
+
+    #region Read Operations
+
+    [Fact]
+    public async Task GetSectionByIdAsync_ReturnsSectionFromRepository()
+    {
+        var id = Guid.NewGuid();
+        var section = new Section { Id = id, Name = "CS-3A" };
+        _mockSectionRepository.Setup(r => r.GetSectionByIdAsync(id)).ReturnsAsync(section);
+
+        var result = await _service.GetSectionByIdAsync(id);
+
+        Assert.Same(section, result);
     }
 
     [Fact]
-    public async Task GetSectionByUuidAsync_ReturnsSection_WhenFound()
+    public async Task GetSectionByIdAsync_ThrowsEntityNotFoundException_WhenMissing()
     {
-        var sectionUuid = Guid.NewGuid();
-        var section = new Section { Id = sectionUuid, Name = "CS-3A", CourseId = Guid.NewGuid() };
-        _mockSectionRepository
-            .Setup(repository => repository.GetSectionByUuidAsync(sectionUuid))
-            .ReturnsAsync(section);
+        var id = Guid.NewGuid();
+        _mockSectionRepository.Setup(r => r.GetSectionByIdAsync(id)).ReturnsAsync((Section?)null);
 
-        var result = await _service.GetSectionByUuidAsync(sectionUuid);
+        await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(() => _service.GetSectionByIdAsync(id));
+    }
+
+    [Fact]
+    public async Task GetSectionByUuidAsync_ReturnsSectionFromRepository()
+    {
+        var id = Guid.NewGuid();
+        var section = new Section { Id = id, Name = "CS-3A" };
+        _mockSectionRepository.Setup(r => r.GetSectionByUuidAsync(id)).ReturnsAsync(section);
+
+        var result = await _service.GetSectionByUuidAsync(id);
 
         Assert.Same(section, result);
     }
@@ -37,223 +62,217 @@ public class SectionServiceTest
     [Fact]
     public async Task GetSectionByUuidAsync_ThrowsEntityNotFoundException_WhenMissing()
     {
-        var sectionUuid = Guid.NewGuid();
-        _mockSectionRepository
-            .Setup(repository => repository.GetSectionByUuidAsync(sectionUuid))
-            .ReturnsAsync((Section?)null);
+        var id = Guid.NewGuid();
+        _mockSectionRepository.Setup(r => r.GetSectionByUuidAsync(id)).ReturnsAsync((Section?)null);
 
-        var exception = await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(() => _service.GetSectionByUuidAsync(sectionUuid));
+        await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(() => _service.GetSectionByUuidAsync(id));
+    }
+
+    [Fact]
+    public async Task GetAllSectionsAsync_ReturnsMappedDtos()
+    {
+        var sections = new List<Section>
+        {
+            new() { Id = Guid.NewGuid(), Name = "CS-3A", Course = new Course { Id = Guid.NewGuid() } },
+            new() { Id = Guid.NewGuid(), Name = "CS-3B", Course = new Course { Id = Guid.NewGuid() } }
+        };
+        _mockSectionRepository.Setup(r => r.GetAllSectionsAsync()).ReturnsAsync(sections);
+
+        var result = await _service.GetAllSectionsAsync();
+
+        var dtos = result.ToList();
+        Assert.Equal(2, dtos.Count);
+        Assert.Equal("CS-3A", dtos[0].Name);
+        Assert.Equal(sections[0].Course.Id, dtos[0].CourseId);
+    }
+
+    #endregion
+
+    #region Create Operations
+
+    [Fact]
+    public async Task CreateSectionAsync_DelegatesAndMapsToDto()
+    {
+        var section = new Section { Name = "CS-3A", CourseId = Guid.NewGuid() };
+        var created = new Section { Id = Guid.NewGuid(), Name = "CS-3A" };
+        var refreshed = new Section { Id = created.Id, Name = "CS-3A", Course = new Course { Id = section.CourseId } };
+
+        _mockCrudService.Setup(s => s.CreateAsync(section)).ReturnsAsync(created);
+        _mockSectionRepository.Setup(r => r.GetSectionByIdAsync(created.Id)).ReturnsAsync(refreshed);
+
+        var result = await _service.CreateSectionAsync(section);
+
+        Assert.IsType<SectionResponseDto>(result);
+        Assert.Equal(created.Id, result.Id);
+        Assert.Equal(refreshed.Course.Id, result.CourseId);
+    }
+
+    #endregion
+
+    #region Update Operations
+
+    [Fact]
+    public async Task UpdateSectionAsync_DelegatesAndMapsToDto()
+    {
+        var id = Guid.NewGuid();
+        var section = new Section { Name = "Updated", CourseId = Guid.NewGuid() };
+        var updated = new Section { Id = id, Name = "Updated" };
+        var refreshed = new Section { Id = id, Name = "Updated", Course = new Course { Id = section.CourseId } };
+
+        _mockCrudService.Setup(s => s.UpdateAsync(id, section)).ReturnsAsync(updated);
+        _mockSectionRepository.Setup(r => r.GetSectionByIdAsync(id)).ReturnsAsync(refreshed);
+
+        var result = await _service.UpdateSectionAsync(id, section);
+
+        Assert.IsType<SectionResponseDto>(result);
+        Assert.Equal(id, result.Id);
+    }
+
+    [Fact]
+    public async Task UpdateSectionByUuidAsync_DelegatesAndMapsToDto()
+    {
+        var id = Guid.NewGuid();
+        var section = new Section { Name = "Updated", CourseId = Guid.NewGuid() };
+        var updated = new Section { Id = id, Name = "Updated" };
+        var refreshed = new Section { Id = id, Name = "Updated", Course = new Course { Id = section.CourseId } };
+
+        _mockCrudService.Setup(s => s.UpdateAsync(id, section)).ReturnsAsync(updated);
+        _mockSectionRepository.Setup(r => r.GetSectionByIdAsync(id)).ReturnsAsync(refreshed);
+
+        var result = await _service.UpdateSectionByUuidAsync(id, section);
+
+        Assert.IsType<SectionResponseDto>(result);
+    }
+
+    #endregion
+
+    #region Delete Operations
+
+    [Fact]
+    public async Task DeleteSectionAsync_DelegatesToCrudService()
+    {
+        var id = Guid.NewGuid();
+        _mockCrudService.Setup(s => s.DeleteAsync(id)).Returns(Task.CompletedTask);
+
+        await _service.DeleteSectionAsync(id);
+
+        _mockCrudService.Verify(s => s.DeleteAsync(id), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteSectionByUuidAsync_DelegatesToCrudService()
+    {
+        var id = Guid.NewGuid();
+        _mockCrudService.Setup(s => s.DeleteAsync(id)).Returns(Task.CompletedTask);
+
+        await _service.DeleteSectionByUuidAsync(id);
+
+        _mockCrudService.Verify(s => s.DeleteAsync(id), Times.Once);
+    }
+
+    #endregion
+
+    #region Student Operations
+
+    [Fact]
+    public async Task GetActiveStudentsBySectionIdAsync_ReturnsRepositoryResult()
+    {
+        var sectionId = Guid.NewGuid();
+        var students = new List<Student> { new() { Id = Guid.NewGuid() } };
+        _mockSectionRepository.Setup(r => r.GetActiveStudentsBySectionIdAsync(sectionId)).ReturnsAsync(students);
+
+        var result = await _service.GetActiveStudentsBySectionIdAsync(sectionId);
+
+        Assert.Equal(students, result);
+    }
+
+    [Fact]
+    public async Task GetAllStudentsBySectionIdAsync_ReturnsRepositoryResult()
+    {
+        var sectionId = Guid.NewGuid();
+        var students = new List<Student> { new() { Id = Guid.NewGuid() } };
+        _mockSectionRepository.Setup(r => r.GetAllStudentsBySectionIdAsync(sectionId)).ReturnsAsync(students);
+
+        var result = await _service.GetAllStudentsBySectionIdAsync(sectionId);
+
+        Assert.Equal(students, result);
+    }
+
+    #endregion
+
+    #region Dependency Check Operations
+
+    [Fact]
+    public async Task HasStudentsInSectionAsync_ReturnsRepositoryResult()
+    {
+        _mockSectionRepository.Setup(r => r.HasStudentsInSectionAsync(It.IsAny<Guid>())).ReturnsAsync(true);
+
+        var result = await _service.HasStudentsInSectionAsync(Guid.NewGuid());
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task HasStudentsInSectionAsync_WrapsUnexpectedFailures()
+    {
+        var expectedException = new InvalidOperationException("Lookup failed");
+        _mockSectionRepository.Setup(r => r.HasStudentsInSectionAsync(It.IsAny<Guid>())).ThrowsAsync(expectedException);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.HasStudentsInSectionAsync(Guid.NewGuid()));
 
         Assert.Equal("Section", exception.EntityName);
-        Assert.Equal(sectionUuid, exception.Key);
+        Assert.Contains("HasStudentsInSection:", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task HasStudentEnrollmentsInSectionAsync_ReturnsRepositoryResult()
+    {
+        _mockSectionRepository.Setup(r => r.HasStudentEnrollmentsInSectionAsync(It.IsAny<Guid>())).ReturnsAsync(true);
+
+        var result = await _service.HasStudentEnrollmentsInSectionAsync(Guid.NewGuid());
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task HasStudentEnrollmentsInSectionAsync_WrapsUnexpectedFailures()
+    {
+        var expectedException = new InvalidOperationException("Lookup failed");
+        _mockSectionRepository.Setup(r => r.HasStudentEnrollmentsInSectionAsync(It.IsAny<Guid>())).ThrowsAsync(expectedException);
+
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.HasStudentEnrollmentsInSectionAsync(Guid.NewGuid()));
+
+        Assert.Equal("Section", exception.EntityName);
+        Assert.Contains("HasStudentEnrollmentsInSection:", exception.Operation);
+        Assert.Same(expectedException, exception.InnerException);
     }
 
     [Fact]
     public async Task HasSchedulesInSectionAsync_ReturnsRepositoryResult()
     {
-        // Arrange
-        var sectionId = Guid.NewGuid();
-        _mockSectionRepository
-            .Setup(repository => repository.HasSchedulesInSectionAsync(sectionId))
-            .ReturnsAsync(true);
+        _mockSectionRepository.Setup(r => r.HasSchedulesInSectionAsync(It.IsAny<Guid>())).ReturnsAsync(true);
 
-        // Act
-        var result = await _service.HasSchedulesInSectionAsync(sectionId);
+        var result = await _service.HasSchedulesInSectionAsync(Guid.NewGuid());
 
-        // Assert
         Assert.True(result);
-        _mockSectionRepository.Verify(repository => repository.HasSchedulesInSectionAsync(sectionId), Times.Once);
     }
 
     [Fact]
-    public async Task HasSchedulesInSectionAsync_WrapsUnexpectedRepositoryFailures()
+    public async Task HasSchedulesInSectionAsync_WrapsUnexpectedFailures()
     {
-        // Arrange
-        var sectionId = Guid.NewGuid();
-        var expectedException = new InvalidOperationException("Schedule lookup failed");
-        _mockSectionRepository
-            .Setup(repository => repository.HasSchedulesInSectionAsync(sectionId))
-            .ThrowsAsync(expectedException);
+        var expectedException = new InvalidOperationException("Lookup failed");
+        _mockSectionRepository.Setup(r => r.HasSchedulesInSectionAsync(It.IsAny<Guid>())).ThrowsAsync(expectedException);
 
-        // Act
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.HasSchedulesInSectionAsync(sectionId));
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.HasSchedulesInSectionAsync(Guid.NewGuid()));
 
-        // Assert
         Assert.Equal("Section", exception.EntityName);
-        Assert.Equal($"HasSchedulesInSection: {sectionId}", exception.Operation);
-        Assert.Equal("Error checking section dependencies", exception.Message);
+        Assert.Contains("HasSchedulesInSection:", exception.Operation);
         Assert.Same(expectedException, exception.InnerException);
     }
 
-    [Fact]
-    public async Task DeleteSectionAsync_Success_DeletesSection()
-    {
-        // Arrange
-        var sectionId = Guid.NewGuid();
-        _mockSectionRepository
-            .Setup(repository => repository.DeleteSectionAsync(sectionId))
-            .ReturnsAsync(true);
-        _mockSectionRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ReturnsAsync(1);
-
-        // Act
-        await _service.DeleteSectionAsync(sectionId);
-
-        // Assert
-        _mockSectionRepository.Verify(repository => repository.DeleteSectionAsync(sectionId), Times.Once);
-        _mockSectionRepository.Verify(repository => repository.SaveChangesAsync(), Times.Once);
-    }
-
-    [Fact]
-    public async Task DeleteSectionAsync_NotFound_ThrowsEntityNotFoundException()
-    {
-        // Arrange
-        var sectionId = Guid.NewGuid();
-        _mockSectionRepository
-            .Setup(repository => repository.DeleteSectionAsync(sectionId))
-            .ReturnsAsync(false);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(() => _service.DeleteSectionAsync(sectionId));
-        Assert.Equal("Section", exception.EntityName);
-        Assert.Equal(sectionId, exception.Key);
-    }
-
-    [Fact]
-    public async Task DeleteSectionAsync_SchedulesConflict_ThrowsEntityConflictException()
-    {
-        // Arrange
-        var sectionId = Guid.NewGuid();
-        _mockSectionRepository
-            .Setup(repository => repository.DeleteSectionAsync(sectionId))
-            .ReturnsAsync(true);
-
-        var innerException = new Exception("The DELETE statement conflicted with the REFERENCE constraint \"FK_Schedules_Sections\". The conflict occurred in database \"attendance_db\", table \"dbo.Schedules\"");
-        var dbUpdateException = new DbUpdateException("Update exception", innerException);
-
-        _mockSectionRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ThrowsAsync(dbUpdateException);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityConflictException>(() => _service.DeleteSectionAsync(sectionId));
-        Assert.Equal("Section", exception.EntityName);
-        Assert.Equal("schedules", exception.ConflictType);
-        Assert.Contains("schedules", exception.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public async Task DeleteSectionAsync_StudentsConflict_ThrowsEntityConflictException()
-    {
-        // Arrange
-        var sectionId = Guid.NewGuid();
-        _mockSectionRepository
-            .Setup(repository => repository.DeleteSectionAsync(sectionId))
-            .ReturnsAsync(true);
-
-        var innerException = new Exception("The DELETE statement conflicted with the REFERENCE constraint \"FK_Students_Sections\". The conflict occurred in database \"attendance_db\", table \"dbo.Students\"");
-        var dbUpdateException = new DbUpdateException("Update exception", innerException);
-
-        _mockSectionRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ThrowsAsync(dbUpdateException);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityConflictException>(() => _service.DeleteSectionAsync(sectionId));
-        Assert.Equal("Section", exception.EntityName);
-        Assert.Equal("students", exception.ConflictType);
-        Assert.Contains("students", exception.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public async Task DeleteSectionAsync_EnrollmentsConflict_ThrowsEntityConflictException()
-    {
-        // Arrange
-        var sectionId = Guid.NewGuid();
-        _mockSectionRepository
-            .Setup(repository => repository.DeleteSectionAsync(sectionId))
-            .ReturnsAsync(true);
-
-        var innerException = new Exception("The DELETE statement conflicted with the REFERENCE constraint \"FK_StudentEnrollments_Sections\". The conflict occurred in database \"attendance_db\", table \"dbo.StudentEnrollments\"");
-        var dbUpdateException = new DbUpdateException("Update exception", innerException);
-
-        _mockSectionRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ThrowsAsync(dbUpdateException);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityConflictException>(() => _service.DeleteSectionAsync(sectionId));
-        Assert.Equal("Section", exception.EntityName);
-        Assert.Equal("enrollments", exception.ConflictType);
-        Assert.Contains("enrollments", exception.Message, StringComparison.OrdinalIgnoreCase);
-    }
-
-    [Fact]
-    public async Task DeleteSectionAsync_UnrelatedException_ThrowsEntityServiceException()
-    {
-        // Arrange
-        var sectionId = Guid.NewGuid();
-        _mockSectionRepository
-            .Setup(repository => repository.DeleteSectionAsync(sectionId))
-            .ReturnsAsync(true);
-
-        var expectedException = new InvalidOperationException("Unexpected database error");
-        _mockSectionRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ThrowsAsync(expectedException);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteSectionAsync(sectionId));
-        Assert.Equal("Section", exception.EntityName);
-        Assert.Equal($"DeleteSection: {sectionId}", exception.Operation);
-        Assert.Same(expectedException, exception.InnerException);
-    }
-
-    [Fact]
-    public async Task DeleteSectionAsync_PostgreSQLSchedulesConflict_ThrowsEntityConflictException()
-    {
-        // Arrange
-        var sectionId = Guid.NewGuid();
-        _mockSectionRepository
-            .Setup(repository => repository.DeleteSectionAsync(sectionId))
-            .ReturnsAsync(true);
-
-        var innerException = new Exception("23503: insert or update on table \"Schedules\" violates foreign key constraint \"FK_Schedules_Sections\"");
-        var dbUpdateException = new DbUpdateException("Update exception", innerException);
-
-        _mockSectionRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ThrowsAsync(dbUpdateException);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityConflictException>(() => _service.DeleteSectionAsync(sectionId));
-        Assert.Equal("Section", exception.EntityName);
-        Assert.Equal("schedules", exception.ConflictType);
-    }
-
-    [Fact]
-    public async Task DeleteSectionAsync_GenericConstraintViolation_ThrowsEntityServiceException()
-    {
-        // Arrange
-        var sectionId = Guid.NewGuid();
-        _mockSectionRepository
-            .Setup(repository => repository.DeleteSectionAsync(sectionId))
-            .ReturnsAsync(true);
-
-        // A constraint violation that is NOT a foreign key violation
-        // This should NOT be matched as a dependency conflict
-        var innerException = new Exception("constraint violation: value violates check constraint \"CK_Sections_NameNotEmpty\"");
-        var dbUpdateException = new DbUpdateException("Update exception", innerException);
-
-        _mockSectionRepository
-            .Setup(repository => repository.SaveChangesAsync())
-            .ThrowsAsync(dbUpdateException);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteSectionAsync(sectionId));
-        Assert.Equal("Section", exception.EntityName);
-        Assert.Equal($"DeleteSection: {sectionId}", exception.Operation);
-        Assert.Same(dbUpdateException, exception.InnerException);
-    }
+    #endregion
 }

--- a/attendance.testproject/Services_Testing/SubjectServiceTest.cs
+++ b/attendance.testproject/Services_Testing/SubjectServiceTest.cs
@@ -3,670 +3,279 @@ using attendance_monitoring.Exceptions;
 using attendance_monitoring.IRepository;
 using attendance_monitoring.Models.DTO.Request;
 using attendance_monitoring.Services;
-using Microsoft.EntityFrameworkCore;
+using attendance_monitoring.Services.Crud;
 using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace attendance.testproject.Services_Testing;
 
-/// <summary>
-/// Unit tests for SubjectService
-/// Tests all public methods with happy paths, edge cases, and error scenarios
-/// </summary>
 public class SubjectServiceTest
 {
     private readonly Mock<ISubjectRepository> _mockSubjectRepository;
+    private readonly Mock<ICrudService<Subject, CreateSubject, UpdateSubject>> _mockCrudService;
     private readonly Mock<ILogger<SubjectService>> _mockLogger;
     private readonly SubjectService _service;
 
     public SubjectServiceTest()
     {
         _mockSubjectRepository = new Mock<ISubjectRepository>();
+        _mockCrudService = new Mock<ICrudService<Subject, CreateSubject, UpdateSubject>>();
         _mockLogger = new Mock<ILogger<SubjectService>>();
-        _service = new SubjectService(_mockSubjectRepository.Object, _mockLogger.Object);
+        _service = new SubjectService(_mockCrudService.Object, _mockSubjectRepository.Object, _mockLogger.Object);
     }
 
-    #region Constructor Tests
+    #region GetAllSubjectsAsync
 
     [Fact]
-    public void Constructor_NullDependency_ThrowsArgumentNullException()
+    public async Task GetAllSubjectsAsync_DelegatesToCrudService()
     {
-        // Arrange & Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new SubjectService(null!, _mockLogger.Object));
-        Assert.Throws<ArgumentNullException>(() => new SubjectService(_mockSubjectRepository.Object, null!));
-    }
-
-    #endregion
-
-    #region GetAllSubjectsAsync Tests
-
-    [Fact]
-    public async Task GetAllSubjectsAsync_Success_ReturnsAllSubjects()
-    {
-        // Arrange
         var subjects = new List<Subject>
         {
-            new Subject { Id = Guid.NewGuid(), Name = "Mathematics", Code = "MATH101" },
-            new Subject { Id = Guid.NewGuid(), Name = "Physics", Code = "PHYS101" }
+            new() { Id = Guid.NewGuid(), Name = "Mathematics", Code = "MATH101" },
+            new() { Id = Guid.NewGuid(), Name = "Physics", Code = "PHYS101" }
         };
-        _mockSubjectRepository.Setup(r => r.GetAllSubjectsAsync()).ReturnsAsync(subjects);
+        _mockCrudService.Setup(s => s.GetAllAsync()).ReturnsAsync(subjects);
 
-        // Act
         var result = await _service.GetAllSubjectsAsync();
 
-        // Assert
-        Assert.NotNull(result);
-        Assert.Equal(2, result.Count());
-        _mockSubjectRepository.Verify(r => r.GetAllSubjectsAsync(), Times.Once);
-    }
-
-    [Fact]
-    public async Task GetAllSubjectsAsync_RepositoryFailure_WrapsInEntityServiceException()
-    {
-        // Arrange
-        var expectedException = new InvalidOperationException("Database error");
-        _mockSubjectRepository.Setup(r => r.GetAllSubjectsAsync()).ThrowsAsync(expectedException);
-
-        // Act
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.GetAllSubjectsAsync());
-
-        // Assert
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal("GetAllSubjects", exception.Operation);
-        Assert.Same(expectedException, exception.InnerException);
+        Assert.Equal(subjects, result);
+        _mockCrudService.Verify(s => s.GetAllAsync(), Times.Once);
     }
 
     #endregion
 
-    #region GetSubjectByIdAsync Tests
+    #region GetSubjectByIdAsync
 
     [Fact]
-    public async Task GetSubjectByIdAsync_Success_ReturnsSubject()
+    public async Task GetSubjectByIdAsync_DelegatesToCrudService()
     {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var subject = new Subject { Id = subjectId, Name = "Mathematics", Code = "MATH101" };
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync(subject);
+        var id = Guid.NewGuid();
+        var subject = new Subject { Id = id, Name = "Mathematics", Code = "MATH101" };
+        _mockCrudService.Setup(s => s.GetByIdAsync(id)).ReturnsAsync(subject);
 
-        // Act
-        var result = await _service.GetSubjectByIdAsync(subjectId);
+        var result = await _service.GetSubjectByIdAsync(id);
 
-        // Assert
-        Assert.NotNull(result);
-        Assert.Equal(subjectId, result.Id);
-        Assert.Equal("Mathematics", result.Name);
-        _mockSubjectRepository.Verify(r => r.GetSubjectByIdAsync(subjectId), Times.Once);
+        Assert.Same(subject, result);
+        _mockCrudService.Verify(s => s.GetByIdAsync(id), Times.Once);
     }
 
     [Fact]
-    public async Task GetSubjectByIdAsync_NotFound_ThrowsEntityNotFoundException()
+    public async Task GetSubjectByIdAsync_ThrowsEntityNotFoundException_WhenMissing()
     {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync((Subject?)null);
+        var id = Guid.NewGuid();
+        _mockCrudService.Setup(s => s.GetByIdAsync(id))
+            .ThrowsAsync(new EntityNotFoundException<Guid>("Subject", id));
 
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(() => _service.GetSubjectByIdAsync(subjectId));
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal(subjectId, exception.Key);
-    }
-
-    [Fact]
-    public async Task GetSubjectByIdAsync_RepositoryFailure_WrapsInEntityServiceException()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var expectedException = new InvalidOperationException("Database error");
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ThrowsAsync(expectedException);
-
-        // Act
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.GetSubjectByIdAsync(subjectId));
-
-        // Assert
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal($"GetSubjectById: {subjectId}", exception.Operation);
-        Assert.Same(expectedException, exception.InnerException);
-    }
-
-    [Fact]
-    public async Task GetSubjectByUuidAsync_Success_ReturnsSubject()
-    {
-        var subjectUuid = Guid.NewGuid();
-        var subject = new Subject { Id = subjectUuid, Name = "Mathematics", Code = "MATH101" };
-        _mockSubjectRepository.Setup(r => r.GetSubjectByUuidAsync(subjectUuid)).ReturnsAsync(subject);
-
-        var result = await _service.GetSubjectByUuidAsync(subjectUuid);
-
-        Assert.NotNull(result);
-        Assert.Equal(subjectUuid, result.Id);
-    }
-
-    [Fact]
-    public async Task GetSubjectByUuidAsync_NotFound_ThrowsEntityNotFoundException()
-    {
-        var subjectUuid = Guid.NewGuid();
-        _mockSubjectRepository.Setup(r => r.GetSubjectByUuidAsync(subjectUuid)).ReturnsAsync((Subject?)null);
-
-        var exception = await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(() => _service.GetSubjectByUuidAsync(subjectUuid));
+        var exception = await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(
+            () => _service.GetSubjectByIdAsync(id));
 
         Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal(subjectUuid, exception.Key);
     }
 
     #endregion
 
-    #region CreateSubjectAsync Tests
+    #region GetSubjectByUuidAsync
 
     [Fact]
-    public async Task CreateSubjectAsync_Success_CreatesSubject()
+    public async Task GetSubjectByUuidAsync_DelegatesToCrudService()
     {
-        // Arrange
-        var createSubject = new CreateSubject
-        {
-            Name = "Mathematics",
-            Code = "MATH101"
-        };
-        Subject? capturedSubject = null;
+        var id = Guid.NewGuid();
+        var subject = new Subject { Id = id, Name = "Mathematics", Code = "MATH101" };
+        _mockCrudService.Setup(s => s.GetByIdAsync(id)).ReturnsAsync(subject);
 
-        _mockSubjectRepository.Setup(r => r.GetSubjectByCodeAsync("MATH101")).ReturnsAsync((Subject?)null);
+        var result = await _service.GetSubjectByUuidAsync(id);
+
+        Assert.Same(subject, result);
+        _mockCrudService.Verify(s => s.GetByIdAsync(id), Times.Once);
+    }
+
+    #endregion
+
+    #region CreateSubjectAsync
+
+    [Fact]
+    public async Task CreateSubjectAsync_DelegatesToCrudService()
+    {
+        var dto = new CreateSubject { Name = "Mathematics", Code = "MATH101" };
+        var created = new Subject { Id = Guid.NewGuid(), Name = "Mathematics", Code = "MATH101" };
+        _mockCrudService.Setup(s => s.CreateAsync(dto)).ReturnsAsync(created);
+
+        var result = await _service.CreateSubjectAsync(dto);
+
+        Assert.Same(created, result);
+        _mockCrudService.Verify(s => s.CreateAsync(dto), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateSubjectAsync_PropagatesValidationException()
+    {
+        var dto = new CreateSubject { Name = "", Code = "MATH101" };
+        _mockCrudService.Setup(s => s.CreateAsync(dto))
+            .ThrowsAsync(new ValidationException("Code is required"));
+
+        await Assert.ThrowsAsync<ValidationException>(() => _service.CreateSubjectAsync(dto));
+    }
+
+    [Fact]
+    public async Task CreateSubjectAsync_PropagatesEntityAlreadyExistsException()
+    {
+        var dto = new CreateSubject { Name = "Mathematics", Code = "MATH101" };
+        _mockCrudService.Setup(s => s.CreateAsync(dto))
+            .ThrowsAsync(new EntityAlreadyExistsException<string>("Subject", "Code", "MATH101"));
+
+        var exception = await Assert.ThrowsAsync<EntityAlreadyExistsException<string>>(
+            () => _service.CreateSubjectAsync(dto));
+
+        Assert.Equal("MATH101", exception.EntityIdentifier);
+    }
+
+    #endregion
+
+    #region UpdateSubjectAsync
+
+    [Fact]
+    public async Task UpdateSubjectAsync_DelegatesToCrudService()
+    {
+        var id = Guid.NewGuid();
+        var dto = new UpdateSubject { Name = "Updated", Code = "MATH101" };
+        var updated = new Subject { Id = id, Name = "Updated", Code = "MATH101" };
+        _mockCrudService.Setup(s => s.UpdateAsync(id, dto)).ReturnsAsync(updated);
+
+        var result = await _service.UpdateSubjectAsync(id, dto);
+
+        Assert.Same(updated, result);
+        _mockCrudService.Verify(s => s.UpdateAsync(id, dto), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateSubjectAsync_PropagatesEntityNotFoundException()
+    {
+        var id = Guid.NewGuid();
+        var dto = new UpdateSubject { Name = "Updated", Code = "MATH101" };
+        _mockCrudService.Setup(s => s.UpdateAsync(id, dto))
+            .ThrowsAsync(new EntityNotFoundException<Guid>("Subject", id));
+
+        await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(
+            () => _service.UpdateSubjectAsync(id, dto));
+    }
+
+    #endregion
+
+    #region UpdateSubjectByUuidAsync
+
+    [Fact]
+    public async Task UpdateSubjectByUuidAsync_DelegatesToCrudService()
+    {
+        var id = Guid.NewGuid();
+        var dto = new UpdateSubject { Name = "Updated", Code = "MATH101" };
+        var updated = new Subject { Id = id, Name = "Updated", Code = "MATH101" };
+        _mockCrudService.Setup(s => s.UpdateAsync(id, dto)).ReturnsAsync(updated);
+
+        var result = await _service.UpdateSubjectByUuidAsync(id, dto);
+
+        Assert.Same(updated, result);
+        _mockCrudService.Verify(s => s.UpdateAsync(id, dto), Times.Once);
+    }
+
+    #endregion
+
+    #region DeleteSubjectAsync
+
+    [Fact]
+    public async Task DeleteSubjectAsync_DelegatesToCrudService()
+    {
+        var id = Guid.NewGuid();
+        _mockCrudService.Setup(s => s.DeleteAsync(id)).Returns(Task.CompletedTask);
+
+        await _service.DeleteSubjectAsync(id);
+
+        _mockCrudService.Verify(s => s.DeleteAsync(id), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteSubjectAsync_PropagatesEntityNotFoundException()
+    {
+        var id = Guid.NewGuid();
+        _mockCrudService.Setup(s => s.DeleteAsync(id))
+            .ThrowsAsync(new EntityNotFoundException<Guid>("Subject", id));
+
+        await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(
+            () => _service.DeleteSubjectAsync(id));
+    }
+
+    #endregion
+
+    #region DeleteSubjectByUuidAsync
+
+    [Fact]
+    public async Task DeleteSubjectByUuidAsync_DelegatesToCrudService()
+    {
+        var id = Guid.NewGuid();
+        _mockCrudService.Setup(s => s.DeleteAsync(id)).Returns(Task.CompletedTask);
+
+        await _service.DeleteSubjectByUuidAsync(id);
+
+        _mockCrudService.Verify(s => s.DeleteAsync(id), Times.Once);
+    }
+
+    #endregion
+
+    #region Dependency Check Operations
+
+    [Fact]
+    public async Task HasSchedulesInSubjectAsync_ReturnsRepositoryResult()
+    {
         _mockSubjectRepository
-            .Setup(r => r.CreateSubject(It.IsAny<Subject>()))
-            .Callback<Subject>(subject => capturedSubject = subject)
-            .ReturnsAsync((Subject subject) => subject);
-        _mockSubjectRepository.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
+            .Setup(r => r.HasSchedulesInSubjectAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(true);
 
-        // Act
-        var createdAtLowerBound = DateTime.UtcNow;
-        var result = await _service.CreateSubjectAsync(createSubject);
-        var createdAtUpperBound = DateTime.UtcNow;
+        var result = await _service.HasSchedulesInSubjectAsync(Guid.NewGuid());
 
-        // Assert
-        Assert.NotNull(result);
-        Assert.NotNull(capturedSubject);
-        Assert.Equal("Mathematics", result.Name);
-        Assert.Equal("MATH101", result.Code);
-        Assert.InRange(capturedSubject.CreatedAt, createdAtLowerBound, createdAtUpperBound);
-        Assert.InRange(capturedSubject.UpdatedAt, createdAtLowerBound, createdAtUpperBound);
-        Assert.Equal(capturedSubject.CreatedAt, result.CreatedAt);
-        Assert.Equal(capturedSubject.UpdatedAt, result.UpdatedAt);
-        _mockSubjectRepository.Verify(r => r.CreateSubject(It.IsAny<Subject>()), Times.Once);
-        _mockSubjectRepository.Verify(r => r.SaveChangesAsync(), Times.Once);
-    }
-
-    [Fact]
-    public async Task CreateSubjectAsync_MissingName_ThrowsValidationException()
-    {
-        // Arrange
-        var createSubject = new CreateSubject
-        {
-            Name = "",
-            Code = "MATH101"
-        };
-
-        // Act & Assert
-        await Assert.ThrowsAsync<ValidationException>(() => _service.CreateSubjectAsync(createSubject));
-    }
-
-    [Fact]
-    public async Task CreateSubjectAsync_MissingCode_ThrowsValidationException()
-    {
-        // Arrange
-        var createSubject = new CreateSubject
-        {
-            Name = "Mathematics",
-            Code = ""
-        };
-
-        // Act & Assert
-        await Assert.ThrowsAsync<ValidationException>(() => _service.CreateSubjectAsync(createSubject));
-    }
-
-    [Fact]
-    public async Task CreateSubjectAsync_DuplicateCodePrecheck_ThrowsEntityAlreadyExistsException()
-    {
-        // Arrange
-        var createSubject = new CreateSubject
-        {
-            Name = "Mathematics",
-            Code = "MATH101"
-        };
-        var existingSubject = new Subject { Id = Guid.NewGuid(), Name = "Physics", Code = "MATH101" };
-
-        _mockSubjectRepository.Setup(r => r.GetSubjectByCodeAsync("MATH101")).ReturnsAsync(existingSubject);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityAlreadyExistsException<string>>(() => _service.CreateSubjectAsync(createSubject));
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal("Code", exception.IdentifierPropertyName);
-        Assert.Equal("MATH101", exception.EntityIdentifier);
-    }
-
-    [Fact]
-    public async Task CreateSubjectAsync_DuplicateKeyDbUpdateException_ThrowsEntityAlreadyExistsException()
-    {
-        // Arrange
-        var createSubject = new CreateSubject
-        {
-            Name = "Mathematics",
-            Code = "MATH101"
-        };
-        var innerException = new Exception("Violation of UNIQUE KEY constraint 'UK_Subjects_Code'");
-        var dbUpdateException = new DbUpdateException("Update exception", innerException);
-
-        _mockSubjectRepository.Setup(r => r.GetSubjectByCodeAsync("MATH101")).ReturnsAsync((Subject?)null);
-        _mockSubjectRepository.Setup(r => r.CreateSubject(It.IsAny<Subject>())).ReturnsAsync(new Subject { Id = Guid.NewGuid() });
-        _mockSubjectRepository.Setup(r => r.SaveChangesAsync()).ThrowsAsync(dbUpdateException);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityAlreadyExistsException<string>>(() => _service.CreateSubjectAsync(createSubject));
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal("Code", exception.IdentifierPropertyName);
-        Assert.Equal("MATH101", exception.EntityIdentifier);
-    }
-
-    [Fact]
-    public async Task CreateSubjectAsync_RepositoryFailure_WrapsInEntityServiceException()
-    {
-        // Arrange
-        var createSubject = new CreateSubject
-        {
-            Name = "Mathematics",
-            Code = "MATH101"
-        };
-        var expectedException = new InvalidOperationException("Database error");
-
-        _mockSubjectRepository.Setup(r => r.GetSubjectByCodeAsync("MATH101")).ReturnsAsync((Subject?)null);
-        _mockSubjectRepository.Setup(r => r.CreateSubject(It.IsAny<Subject>())).ThrowsAsync(expectedException);
-
-        // Act
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.CreateSubjectAsync(createSubject));
-
-        // Assert
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal("CreateSubject", exception.Operation);
-    }
-
-    #endregion
-
-    #region UpdateSubjectAsync Tests
-
-    [Fact]
-    public async Task UpdateSubjectAsync_Success_UpdatesSubject()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var updateSubject = new UpdateSubject
-        {
-            Name = "Mathematics Updated",
-            Code = "MATH101"
-        };
-        var existingSubject = new Subject
-        {
-            Id = subjectId,
-            Name = "Mathematics",
-            Code = "MATH101",
-            CreatedAt = DateTime.UtcNow.AddDays(-1),
-            UpdatedAt = DateTime.UtcNow.AddDays(-1)
-        };
-        var updatedSubject = new Subject
-        {
-            Id = subjectId,
-            Name = "Mathematics Updated",
-            Code = "MATH101",
-            CreatedAt = DateTime.UtcNow.AddDays(-1),
-            UpdatedAt = DateTime.UtcNow
-        };
-
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync(existingSubject);
-        _mockSubjectRepository.Setup(r => r.GetSubjectByCodeAsync("MATH101")).ReturnsAsync(existingSubject);
-        _mockSubjectRepository.Setup(r => r.UpdateSubjectAsync(It.IsAny<Subject>())).ReturnsAsync(updatedSubject);
-        _mockSubjectRepository.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
-
-        // Act
-        var result = await _service.UpdateSubjectAsync(subjectId, updateSubject);
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.Equal("Mathematics Updated", result.Name);
-        Assert.Equal("MATH101", result.Code);
-        _mockSubjectRepository.Verify(r => r.UpdateSubjectAsync(It.IsAny<Subject>()), Times.Once);
-        _mockSubjectRepository.Verify(r => r.SaveChangesAsync(), Times.Once);
-    }
-
-    [Fact]
-    public async Task UpdateSubjectAsync_SubjectNotFound_ThrowsEntityNotFoundException()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var updateSubject = new UpdateSubject { Name = "Mathematics", Code = "MATH101" };
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync((Subject?)null);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(() => _service.UpdateSubjectAsync(subjectId, updateSubject));
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal(subjectId, exception.Key);
-    }
-
-    [Fact]
-    public async Task UpdateSubjectAsync_DuplicateCodePrecheck_ThrowsEntityAlreadyExistsException()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var updateSubject = new UpdateSubject { Name = "Mathematics", Code = "PHYS101" };
-        var existingSubject = new Subject { Id = subjectId, Name = "Mathematics", Code = "MATH101" };
-        var duplicateSubject = new Subject { Id = Guid.NewGuid(), Name = "Physics", Code = "PHYS101" };
-
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync(existingSubject);
-        _mockSubjectRepository.Setup(r => r.GetSubjectByCodeAsync("PHYS101")).ReturnsAsync(duplicateSubject);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityAlreadyExistsException<string>>(() => _service.UpdateSubjectAsync(subjectId, updateSubject));
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal("Code", exception.IdentifierPropertyName);
-        Assert.Equal("PHYS101", exception.EntityIdentifier);
-    }
-
-    [Fact]
-    public async Task UpdateSubjectAsync_DuplicateKeyDbUpdateException_ThrowsEntityAlreadyExistsException()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var updateSubject = new UpdateSubject { Name = "Mathematics", Code = "MATH101" };
-        var existingSubject = new Subject { Id = subjectId, Name = "Mathematics", Code = "MATH101" };
-        var innerException = new Exception("Violation of UNIQUE KEY constraint 'UK_Subjects_Code'");
-        var dbUpdateException = new DbUpdateException("Update exception", innerException);
-
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync(existingSubject);
-        _mockSubjectRepository.Setup(r => r.UpdateSubjectAsync(It.IsAny<Subject>())).ReturnsAsync(existingSubject);
-        _mockSubjectRepository.Setup(r => r.SaveChangesAsync()).ThrowsAsync(dbUpdateException);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityAlreadyExistsException<string>>(() => _service.UpdateSubjectAsync(subjectId, updateSubject));
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal("Code", exception.IdentifierPropertyName);
-    }
-
-    [Fact]
-    public async Task UpdateSubjectAsync_SaveChangesAsyncZero_ThrowsEntityServiceException()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var updateSubject = new UpdateSubject { Name = "Mathematics", Code = "MATH101" };
-        var existingSubject = new Subject { Id = subjectId, Name = "Mathematics", Code = "MATH101" };
-
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync(existingSubject);
-        _mockSubjectRepository.Setup(r => r.UpdateSubjectAsync(It.IsAny<Subject>())).ReturnsAsync(existingSubject);
-        _mockSubjectRepository.Setup(r => r.SaveChangesAsync()).ReturnsAsync(0);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.UpdateSubjectAsync(subjectId, updateSubject));
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Contains("may have been updated by another process", exception.Message);
-    }
-
-    [Fact]
-    public async Task UpdateSubjectAsync_RepositoryFailure_WrapsInEntityServiceException()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var updateSubject = new UpdateSubject { Name = "Mathematics", Code = "MATH101" };
-        var existingSubject = new Subject { Id = subjectId, Name = "Mathematics", Code = "MATH101" };
-        var expectedException = new InvalidOperationException("Database error");
-
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync(existingSubject);
-        _mockSubjectRepository.Setup(r => r.UpdateSubjectAsync(It.IsAny<Subject>())).ThrowsAsync(expectedException);
-
-        // Act
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.UpdateSubjectAsync(subjectId, updateSubject));
-
-        // Assert
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal($"UpdateSubject: {subjectId}", exception.Operation);
-    }
-
-    #endregion
-
-    #region HasSchedulesInSubjectAsync Tests
-
-    [Fact]
-    public async Task HasSchedulesInSubjectAsync_Success_ReturnsTrue()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        _mockSubjectRepository.Setup(r => r.HasSchedulesInSubjectAsync(subjectId)).ReturnsAsync(true);
-
-        // Act
-        var result = await _service.HasSchedulesInSubjectAsync(subjectId);
-
-        // Assert
         Assert.True(result);
-        _mockSubjectRepository.Verify(r => r.HasSchedulesInSubjectAsync(subjectId), Times.Once);
     }
 
     [Fact]
-    public async Task HasSchedulesInSubjectAsync_Success_ReturnsFalse()
+    public async Task HasSchedulesInSubjectAsync_WrapsUnexpectedFailures()
     {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        _mockSubjectRepository.Setup(r => r.HasSchedulesInSubjectAsync(subjectId)).ReturnsAsync(false);
+        var expectedException = new InvalidOperationException("Lookup failed");
+        _mockSubjectRepository
+            .Setup(r => r.HasSchedulesInSubjectAsync(It.IsAny<Guid>()))
+            .ThrowsAsync(expectedException);
 
-        // Act
-        var result = await _service.HasSchedulesInSubjectAsync(subjectId);
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.HasSchedulesInSubjectAsync(Guid.NewGuid()));
 
-        // Assert
-        Assert.False(result);
-    }
-
-    [Fact]
-    public async Task HasSchedulesInSubjectAsync_RepositoryFailure_WrapsInEntityServiceException()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var expectedException = new InvalidOperationException("Database error");
-        _mockSubjectRepository.Setup(r => r.HasSchedulesInSubjectAsync(subjectId)).ThrowsAsync(expectedException);
-
-        // Act
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.HasSchedulesInSubjectAsync(subjectId));
-
-        // Assert
         Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal($"HasSchedulesInSubject: {subjectId}", exception.Operation);
+        Assert.Contains("HasSchedulesInSubject:", exception.Operation);
         Assert.Same(expectedException, exception.InnerException);
     }
 
-    #endregion
-
-    #region HasEnrollmentsInSubjectAsync Tests
-
     [Fact]
-    public async Task HasEnrollmentsInSubjectAsync_Success_ReturnsTrue()
+    public async Task HasEnrollmentsInSubjectAsync_ReturnsRepositoryResult()
     {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        _mockSubjectRepository.Setup(r => r.HasEnrollmentsInSubjectAsync(subjectId)).ReturnsAsync(true);
+        _mockSubjectRepository
+            .Setup(r => r.HasEnrollmentsInSubjectAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(true);
 
-        // Act
-        var result = await _service.HasEnrollmentsInSubjectAsync(subjectId);
+        var result = await _service.HasEnrollmentsInSubjectAsync(Guid.NewGuid());
 
-        // Assert
         Assert.True(result);
-        _mockSubjectRepository.Verify(r => r.HasEnrollmentsInSubjectAsync(subjectId), Times.Once);
     }
 
     [Fact]
-    public async Task HasEnrollmentsInSubjectAsync_Success_ReturnsFalse()
+    public async Task HasEnrollmentsInSubjectAsync_WrapsUnexpectedFailures()
     {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        _mockSubjectRepository.Setup(r => r.HasEnrollmentsInSubjectAsync(subjectId)).ReturnsAsync(false);
+        var expectedException = new InvalidOperationException("Lookup failed");
+        _mockSubjectRepository
+            .Setup(r => r.HasEnrollmentsInSubjectAsync(It.IsAny<Guid>()))
+            .ThrowsAsync(expectedException);
 
-        // Act
-        var result = await _service.HasEnrollmentsInSubjectAsync(subjectId);
+        var exception = await Assert.ThrowsAsync<EntityServiceException>(
+            () => _service.HasEnrollmentsInSubjectAsync(Guid.NewGuid()));
 
-        // Assert
-        Assert.False(result);
-    }
-
-    [Fact]
-    public async Task HasEnrollmentsInSubjectAsync_RepositoryFailure_WrapsInEntityServiceException()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var expectedException = new InvalidOperationException("Database error");
-        _mockSubjectRepository.Setup(r => r.HasEnrollmentsInSubjectAsync(subjectId)).ThrowsAsync(expectedException);
-
-        // Act
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.HasEnrollmentsInSubjectAsync(subjectId));
-
-        // Assert
         Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal($"HasEnrollmentsInSubject: {subjectId}", exception.Operation);
+        Assert.Contains("HasEnrollmentsInSubject:", exception.Operation);
         Assert.Same(expectedException, exception.InnerException);
-    }
-
-    #endregion
-
-    #region DeleteSubjectAsync Tests
-
-    [Fact]
-    public async Task DeleteSubjectAsync_Success_DeletesSubject()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var existingSubject = new Subject { Id = subjectId, Name = "Mathematics", Code = "MATH101" };
-
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync(existingSubject);
-        _mockSubjectRepository.Setup(r => r.DeleteSubjectAsync(subjectId)).ReturnsAsync(true);
-        _mockSubjectRepository.Setup(r => r.SaveChangesAsync()).ReturnsAsync(1);
-
-        // Act
-        await _service.DeleteSubjectAsync(subjectId);
-
-        // Assert
-        _mockSubjectRepository.Verify(r => r.DeleteSubjectAsync(subjectId), Times.Once);
-        _mockSubjectRepository.Verify(r => r.SaveChangesAsync(), Times.Once);
-    }
-
-    [Fact]
-    public async Task DeleteSubjectAsync_SubjectNotFound_ThrowsEntityNotFoundException()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync((Subject?)null);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityNotFoundException<Guid>>(() => _service.DeleteSubjectAsync(subjectId));
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal(subjectId, exception.Key);
-    }
-
-    [Fact]
-    public async Task DeleteSubjectAsync_RepositoryDeleteReturnsFalse_ThrowsEntityServiceException()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var existingSubject = new Subject { Id = subjectId, Name = "Mathematics", Code = "MATH101" };
-
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync(existingSubject);
-        _mockSubjectRepository.Setup(r => r.DeleteSubjectAsync(subjectId)).ReturnsAsync(false);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteSubjectAsync(subjectId));
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Contains("Failed to delete", exception.Message);
-    }
-
-    [Fact]
-    public async Task DeleteSubjectAsync_SaveChangesAsyncZero_ThrowsEntityServiceException()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var existingSubject = new Subject { Id = subjectId, Name = "Mathematics", Code = "MATH101" };
-
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync(existingSubject);
-        _mockSubjectRepository.Setup(r => r.DeleteSubjectAsync(subjectId)).ReturnsAsync(true);
-        _mockSubjectRepository.Setup(r => r.SaveChangesAsync()).ReturnsAsync(0);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteSubjectAsync(subjectId));
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Contains("may have been deleted by another process", exception.Message);
-    }
-
-    [Fact]
-    public async Task DeleteSubjectAsync_SchedulesForeignKeyConflict_ThrowsEntityConflictException()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var existingSubject = new Subject { Id = subjectId, Name = "Mathematics", Code = "MATH101" };
-        var innerException = new Exception("The DELETE statement conflicted with the REFERENCE constraint \"FK_Schedules_Subjects\"");
-        var dbUpdateException = new DbUpdateException("Update exception", innerException);
-
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync(existingSubject);
-        _mockSubjectRepository.Setup(r => r.DeleteSubjectAsync(subjectId)).ReturnsAsync(true);
-        _mockSubjectRepository.Setup(r => r.SaveChangesAsync()).ThrowsAsync(dbUpdateException);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityConflictException>(() => _service.DeleteSubjectAsync(subjectId));
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal("schedules", exception.ConflictType);
-    }
-
-    [Fact]
-    public async Task DeleteSubjectAsync_EnrollmentsForeignKeyConflict_ThrowsEntityConflictException()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var existingSubject = new Subject { Id = subjectId, Name = "Mathematics", Code = "MATH101" };
-        var innerException = new Exception("The DELETE statement conflicted with the REFERENCE constraint \"FK_StudentEnrollments_Subjects\"");
-        var dbUpdateException = new DbUpdateException("Update exception", innerException);
-
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync(existingSubject);
-        _mockSubjectRepository.Setup(r => r.DeleteSubjectAsync(subjectId)).ReturnsAsync(true);
-        _mockSubjectRepository.Setup(r => r.SaveChangesAsync()).ThrowsAsync(dbUpdateException);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityConflictException>(() => _service.DeleteSubjectAsync(subjectId));
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal("enrollments", exception.ConflictType);
-    }
-
-    [Fact]
-    public async Task DeleteSubjectAsync_GenericForeignKeyConflict_ThrowsEntityConflictException()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var existingSubject = new Subject { Id = subjectId, Name = "Mathematics", Code = "MATH101" };
-        var innerException = new Exception("The DELETE statement conflicted with the REFERENCE constraint \"FK_Unknown_Subjects\"");
-        var dbUpdateException = new DbUpdateException("Update exception", innerException);
-
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync(existingSubject);
-        _mockSubjectRepository.Setup(r => r.DeleteSubjectAsync(subjectId)).ReturnsAsync(true);
-        _mockSubjectRepository.Setup(r => r.SaveChangesAsync()).ThrowsAsync(dbUpdateException);
-
-        // Act & Assert
-        var exception = await Assert.ThrowsAsync<EntityConflictException>(() => _service.DeleteSubjectAsync(subjectId));
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal("dependencies", exception.ConflictType);
-    }
-
-    [Fact]
-    public async Task DeleteSubjectAsync_RepositoryFailure_WrapsInEntityServiceException()
-    {
-        // Arrange
-        var subjectId = Guid.NewGuid();
-        var existingSubject = new Subject { Id = subjectId, Name = "Mathematics", Code = "MATH101" };
-        var expectedException = new InvalidOperationException("Database error");
-
-        _mockSubjectRepository.Setup(r => r.GetSubjectByIdAsync(subjectId)).ReturnsAsync(existingSubject);
-        _mockSubjectRepository.Setup(r => r.DeleteSubjectAsync(subjectId)).ThrowsAsync(expectedException);
-
-        // Act
-        var exception = await Assert.ThrowsAsync<EntityServiceException>(() => _service.DeleteSubjectAsync(subjectId));
-
-        // Assert
-        Assert.Equal("Subject", exception.EntityName);
-        Assert.Equal($"DeleteSubject: {subjectId}", exception.Operation);
     }
 
     #endregion

--- a/attendance_monitoring/Extensions/ServiceCollectionExtensions/DependencyInjectionExtensions.cs
+++ b/attendance_monitoring/Extensions/ServiceCollectionExtensions/DependencyInjectionExtensions.cs
@@ -1,8 +1,11 @@
+using attendance_monitoring.Classes;
 using attendance_monitoring.IRepository;
 using attendance_monitoring.IServices;
+using attendance_monitoring.Models.DTO.Request;
 using attendance_monitoring.Options;
 using attendance_monitoring.Repositories;
 using attendance_monitoring.Services;
+using attendance_monitoring.Services.Crud;
 using attendance_monitoring.Services.HealthChecks;
 using attendance_monitoring.Services.Account;
 using attendance_monitoring.Services.AdminData;
@@ -36,6 +39,12 @@ public static class DependencyInjectionExtensions
         services.AddScoped<ISessionRepository, SessionRepository>();
         services.AddScoped<IAttendanceRepository, AttendanceRepository>();
         services.AddScoped<IFingerprintRepository, FingerprintRepository>();
+
+        // Generic CRUD repositories
+        services.AddScoped<IGenericCrudRepository<Classroom>, GenericCrudRepository<Classroom>>();
+        services.AddScoped<IGenericCrudRepository<Subject>, GenericCrudRepository<Subject>>();
+        services.AddScoped<IGenericCrudRepository<Course>, GenericCrudRepository<Course>>();
+        services.AddScoped<IGenericCrudRepository<Section>, GenericCrudRepository<Section>>();
 
         return services;
     }
@@ -77,9 +86,29 @@ public static class DependencyInjectionExtensions
         services.AddScoped<IProfileService, ProfileService>();
         services.AddScoped<IAdminService, AdminService>();
         services.AddScoped<IUserFactory, attendance_monitoring.Classes.Factory.UserFactory>();
+        // Section CRUD via generic module
+        services.AddScoped<CrudServiceConfig<Section, Section, Section>>(_ =>
+            SectionConfig.Create());
+        services.AddScoped<ICrudService<Section, Section, Section>,
+            CrudService<Section, Section, Section>>();
         services.AddScoped<ISectionService, SectionService>();
+        // Course CRUD via generic module
+        services.AddScoped<CrudServiceConfig<Course, CreateCourse, UpdateCourse>>(_ =>
+            CourseConfig.Create());
+        services.AddScoped<ICrudService<Course, CreateCourse, UpdateCourse>,
+            CrudService<Course, CreateCourse, UpdateCourse>>();
         services.AddScoped<ICourseService, CourseService>();
+        // Subject CRUD via generic module
+        services.AddScoped<CrudServiceConfig<Subject, CreateSubject, UpdateSubject>>(sp =>
+            SubjectConfig.Create(sp.GetRequiredService<ISubjectRepository>()));
+        services.AddScoped<ICrudService<Subject, CreateSubject, UpdateSubject>,
+            CrudService<Subject, CreateSubject, UpdateSubject>>();
         services.AddScoped<ISubjectService, SubjectService>();
+        // Classroom CRUD via generic module
+        services.AddScoped<CrudServiceConfig<Classroom, CreateClassroom, UpdateClassroom>>(sp =>
+            ClassroomConfig.Create(sp.GetRequiredService<IClassroomRepository>()));
+        services.AddScoped<ICrudService<Classroom, CreateClassroom, UpdateClassroom>,
+            CrudService<Classroom, CreateClassroom, UpdateClassroom>>();
         services.AddScoped<IClassroomService, ClassroomService>();
         services.AddScoped<IScheduleService, ScheduleService>();
         services.AddScoped<IQrCodeService>(sp => new QrCodeService(

--- a/attendance_monitoring/Extensions/ServiceCollectionExtensions/DependencyInjectionExtensions.cs
+++ b/attendance_monitoring/Extensions/ServiceCollectionExtensions/DependencyInjectionExtensions.cs
@@ -93,8 +93,8 @@ public static class DependencyInjectionExtensions
             CrudService<Section, Section, Section>>();
         services.AddScoped<ISectionService, SectionService>();
         // Course CRUD via generic module
-        services.AddScoped<CrudServiceConfig<Course, CreateCourse, UpdateCourse>>(_ =>
-            CourseConfig.Create());
+        services.AddScoped<CrudServiceConfig<Course, CreateCourse, UpdateCourse>>(sp =>
+            CourseConfig.Create(sp.GetRequiredService<ICourseRepository>()));
         services.AddScoped<ICrudService<Course, CreateCourse, UpdateCourse>,
             CrudService<Course, CreateCourse, UpdateCourse>>();
         services.AddScoped<ICourseService, CourseService>();

--- a/attendance_monitoring/IRepository/ICourseRepository.cs
+++ b/attendance_monitoring/IRepository/ICourseRepository.cs
@@ -62,4 +62,11 @@ public interface ICourseRepository : ISaveableRepository
     /// <returns>True if sections exist for the course; otherwise, false.</returns>
     Task<bool> HasSectionsInCourseAsync(Guid id);
 
+    /// <summary>
+    /// Retrieves a course by its name.
+    /// </summary>
+    /// <param name="name">The course name.</param>
+    /// <returns>The course if found; otherwise, null.</returns>
+    Task<Course?> GetCourseByNameAsync(string name);
+
 }

--- a/attendance_monitoring/Repositories/CourseRepository.cs
+++ b/attendance_monitoring/Repositories/CourseRepository.cs
@@ -78,6 +78,13 @@ public class CourseRepository(ApplicationDbContext context) : ICourseRepository
     }
     #endregion
 
+    #region GetCourseByNameAsync
+    public async Task<Course?> GetCourseByNameAsync(string name)
+    {
+        return await context.Courses.AsNoTracking().FirstOrDefaultAsync(c => c.Name == name).ConfigureAwait(false);
+    }
+    #endregion
+
     #endregion
 
     #region Utility Operations

--- a/attendance_monitoring/Services/ClassroomService.cs
+++ b/attendance_monitoring/Services/ClassroomService.cs
@@ -1,274 +1,79 @@
 using attendance_monitoring.Classes;
 using attendance_monitoring.Exceptions;
-using attendance_monitoring.Helpers;
 using attendance_monitoring.IRepository;
 using attendance_monitoring.IServices;
 using attendance_monitoring.Models.DTO.Request;
-using Microsoft.EntityFrameworkCore;
+using attendance_monitoring.Services.Crud;
 
 namespace attendance_monitoring.Services;
 
 /// <summary>
-/// Service class for managing classroom-related operations
+/// Service class for managing classroom-related operations.
+/// Delegates CRUD operations to the generic CrudService; handles entity-specific
+/// dependency checks via the classroom repository.
 /// </summary>
 public class ClassroomService : IClassroomService
 {
+    private readonly ICrudService<Classroom, CreateClassroom, UpdateClassroom> _crudService;
     private readonly IClassroomRepository _classroomRepository;
     private readonly ILogger<ClassroomService> _logger;
 
-    /// <summary>
-    /// Initializes a new instance of the ClassroomService class
-    /// </summary>
-    /// <param name="classroomRepository">Repository for classroom data operations</param>
-    /// <param name="logger">Logger for logging operations</param>
-    public ClassroomService(IClassroomRepository classroomRepository, ILogger<ClassroomService> logger)
+    public ClassroomService(
+        ICrudService<Classroom, CreateClassroom, UpdateClassroom> crudService,
+        IClassroomRepository classroomRepository,
+        ILogger<ClassroomService> logger)
     {
-        _classroomRepository = classroomRepository ?? throw new ArgumentNullException(nameof(classroomRepository));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _crudService = crudService;
+        _classroomRepository = classroomRepository;
+        _logger = logger;
     }
 
-    #region GetAllClassroomsAsync
-    /// <summary>
-    /// Retrieves all classrooms
-    /// </summary>
-    /// <returns>A collection of classrooms</returns>
+    #region CRUD Operations (delegated to CrudService)
+
     public async Task<IEnumerable<Classroom>> GetAllClassroomsAsync()
     {
-        _logger.LogInformation("Retrieving all classrooms");
-        try
-        {
-            var classrooms = await _classroomRepository.GetAllClassroomsAsync().ConfigureAwait(false);
-            var allClassrooms = classrooms.ToList();
-            _logger.LogInformation("Successfully retrieved {Count} classrooms", allClassrooms.Count);
-            return allClassrooms;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while retrieving all classrooms");
-            throw new EntityServiceException("Classroom", "GetAllClassrooms", "An error occurred while retrieving classrooms", ex);
-        }
+        return await _crudService.GetAllAsync().ConfigureAwait(false);
     }
-    #endregion
 
-    #region GetClassroomByIdAsync
-    /// <summary>
-    /// Retrieves a specific classroom by ID
-    /// </summary>
-    /// <param name="id">The ID of the classroom to retrieve</param>
-    /// <returns>The classroom with the specified ID, or null if not found</returns>
     public async Task<Classroom?> GetClassroomByIdAsync(Guid id)
     {
-        _logger.LogInformation("Retrieving classroom by ID: {Id}", id);
-        try
-        {
-            var classroom = await _classroomRepository.GetClassroomByIdAsync(id).ConfigureAwait(false);
-            if (classroom == null)
-            {
-                _logger.LogWarning("Classroom with ID {Id} not found", id);
-                throw new EntityNotFoundException<Guid>("Classroom", id);
-            }
-
-            _logger.LogInformation("Successfully retrieved classroom with ID: {Id}", id);
-            return classroom;
-        }
-        catch (EntityNotFoundException<Guid>)
-        {
-            // Re-throw the specific exception for the controller to handle
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while retrieving classroom with ID {Id}", id);
-            throw new EntityServiceException("Classroom", $"GetClassroomById: {id}", "An error occurred while retrieving the classroom", ex);
-        }
+        return await _crudService.GetByIdAsync(id).ConfigureAwait(false);
     }
-    #endregion
 
-    #region GetClassroomByUuidAsync
     public async Task<Classroom?> GetClassroomByUuidAsync(Guid id)
     {
-        _logger.LogInformation("Retrieving classroom by UUID: {Id}", id);
-        try
-        {
-            var classroom = await _classroomRepository.GetClassroomByUuidAsync(id).ConfigureAwait(false);
-            if (classroom == null)
-            {
-                _logger.LogWarning("Classroom with UUID {Id} not found", id);
-                throw new EntityNotFoundException<Guid>("Classroom", id);
-            }
-
-            _logger.LogInformation("Successfully retrieved classroom with UUID: {Id}", id);
-            return classroom;
-        }
-        catch (EntityNotFoundException<Guid>)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while retrieving classroom with UUID {Id}", id);
-            throw new EntityServiceException("Classroom", $"GetClassroomByUuid: {id}", "An error occurred while retrieving the classroom", ex);
-        }
+        return await _crudService.GetByIdAsync(id).ConfigureAwait(false);
     }
-    #endregion
 
-    #region CreateClassroomAsync
-    /// <summary>
-    /// Creates a new classroom record
-    /// </summary>
-    /// <param name="createClassroom">The classroom data to create</param>
-    /// <returns>The created classroom</returns>
-    /// <exception cref="ValidationException">Thrown when validation fails</exception>
-    /// <exception cref="EntityAlreadyExistsException{TKey}">Thrown when classroom with name already exists</exception>
-    /// <exception cref="EntityServiceException">Thrown when an error occurs during creation</exception>
     public async Task<Classroom> CreateClassroomAsync(CreateClassroom createClassroom)
     {
-        _logger.LogInformation("Creating new classroom with name: {ClassroomName}", createClassroom.Name);
-
-        try
-        {
-            if (string.IsNullOrWhiteSpace(createClassroom.Name))
-            {
-                _logger.LogWarning("Classroom creation failed: Classroom name is required");
-                throw new ValidationException("Classroom name is required");
-            }
-
-            // Check if a classroom with the same name already exists (first check)
-            var existingClassroom = await _classroomRepository.GetClassroomByNameAsync(createClassroom.Name);
-            if (existingClassroom != null)
-            {
-                _logger.LogWarning("Classroom creation failed: Classroom with name {Name} already exists", createClassroom.Name);
-                throw new EntityAlreadyExistsException<string>("Classroom", "Name", createClassroom.Name);
-            }
-
-            var classroom = new Classroom
-            {
-                Name = createClassroom.Name,
-                CreatedAt = DateTime.UtcNow,
-                UpdatedAt = DateTime.UtcNow
-            };
-
-            try
-            {
-                var createdClassroom = await _classroomRepository.CreateClassroom(classroom).ConfigureAwait(false);
-                await _classroomRepository.SaveChangesAsync().ConfigureAwait(false);
-
-                _logger.LogInformation("Successfully created classroom with ID: {Id} and name: {ClassroomName}", createdClassroom.Id, createdClassroom.Name);
-                return createdClassroom;
-            }
-            catch (DbUpdateException ex) when (ExceptionHandlingHelper.IsUniqueConstraintViolation(ex))
-            {
-                _logger.LogWarning("Classroom creation failed due to unique constraint violation: Classroom with name {Name} already exists", createClassroom.Name);
-                throw new EntityAlreadyExistsException<string>("Classroom", "Name", createClassroom.Name);
-            }
-        }
-        catch (ValidationException)
-        {
-            throw;
-        }
-        catch (EntityAlreadyExistsException<string>)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while creating classroom with name: {ClassroomName}", createClassroom.Name);
-            throw ExceptionHandlingHelper.CreateServiceException("Classroom", "CreateClassroom", ex);
-        }
+        return await _crudService.CreateAsync(createClassroom).ConfigureAwait(false);
     }
-    #endregion
 
-    #region UpdateClassroomAsync
-    /// <summary>
-    /// Updates an existing classroom record
-    /// </summary>
-    /// <param name="id">The ID of the classroom to update</param>
-    /// <param name="updateClassroom">The updated classroom data</param>
-    /// <returns>The updated classroom</returns>
-    /// <exception cref="EntityNotFoundException{TKey}">Thrown when classroom not found</exception>
-    /// <exception cref="EntityAlreadyExistsException{TKey}">Thrown when classroom with name already exists</exception>
-    /// <exception cref="EntityServiceException">Thrown when an error occurs during update</exception>
     public async Task<Classroom> UpdateClassroomAsync(Guid id, UpdateClassroom updateClassroom)
     {
-        _logger.LogInformation("Updating classroom with ID: {Id}", id);
-
-        try
-        {
-            var existingClassroom = await _classroomRepository.GetClassroomByIdAsync(id).ConfigureAwait(false);
-            if (existingClassroom == null)
-            {
-                _logger.LogWarning("Classroom update failed: Classroom with ID {Id} not found", id);
-                throw new EntityNotFoundException<Guid>("Classroom", id);
-            }
-
-            // Check if the new name already exists for another classroom (first check)
-            if (!string.IsNullOrEmpty(updateClassroom.Name) && !updateClassroom.Name.Equals(existingClassroom.Name))
-            {
-                var duplicateClassroom = await _classroomRepository.GetClassroomByNameAsync(updateClassroom.Name);
-                if (duplicateClassroom != null && duplicateClassroom.Id != id)
-                {
-                    _logger.LogWarning("Classroom update failed: Classroom with name {Name} already exists", updateClassroom.Name);
-                    throw new EntityAlreadyExistsException<string>("Classroom", "Name", updateClassroom.Name);
-                }
-            }
-
-            if (!string.IsNullOrEmpty(updateClassroom.Name))
-            {
-                existingClassroom.Name = updateClassroom.Name;
-            }
-
-            existingClassroom.UpdatedAt = DateTime.UtcNow;
-
-            try
-            {
-                var updatedClassroom = await _classroomRepository.UpdateClassroomAsync(existingClassroom).ConfigureAwait(false);
-                var rowsAffected = await _classroomRepository.SaveChangesAsync().ConfigureAwait(false);
-
-                if (rowsAffected == 0)
-                {
-                    _logger.LogWarning("Classroom update failed: Classroom with ID {Id} may have been updated by another process", id);
-                    throw new EntityServiceException("Classroom", $"UpdateClassroom: {id}", "Classroom may have been updated by another process. Please try again.");
-                }
-
-                _logger.LogInformation("Successfully updated classroom with ID: {Id}", id);
-                return updatedClassroom;
-            }
-            catch (DbUpdateException ex) when (ExceptionHandlingHelper.IsUniqueConstraintViolation(ex))
-            {
-                _logger.LogWarning("Classroom update failed due to unique constraint violation: Classroom with name {Name} already exists", updateClassroom.Name);
-                throw new EntityAlreadyExistsException<string>("Classroom", "Name", updateClassroom.Name ?? "");
-            }
-        }
-        catch (EntityNotFoundException<Guid>)
-        {
-            // Re-throw the specific exception for the controller to handle
-            throw;
-        }
-        catch (EntityAlreadyExistsException<string>)
-        {
-            throw;
-        }
-        catch (EntityServiceException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while updating classroom with ID {Id}", id);
-            throw ExceptionHandlingHelper.CreateServiceException("Classroom", $"UpdateClassroom: {id}", ex);
-        }
+        return await _crudService.UpdateAsync(id, updateClassroom).ConfigureAwait(false);
     }
-    #endregion
 
-    #region UpdateClassroomByUuidAsync
     public async Task<Classroom> UpdateClassroomByUuidAsync(Guid id, UpdateClassroom updateClassroom)
     {
-        var existingClassroom = await GetClassroomByUuidAsync(id).ConfigureAwait(false);
-        return await UpdateClassroomAsync(existingClassroom!.Id, updateClassroom).ConfigureAwait(false);
+        return await _crudService.UpdateAsync(id, updateClassroom).ConfigureAwait(false);
     }
+
+    public async Task DeleteClassroomAsync(Guid id)
+    {
+        await _crudService.DeleteAsync(id).ConfigureAwait(false);
+    }
+
+    public async Task DeleteClassroomByUuidAsync(Guid id)
+    {
+        await _crudService.DeleteAsync(id).ConfigureAwait(false);
+    }
+
     #endregion
 
-    #region Dependency Check Operations
+    #region Dependency Check Operations (entity-specific)
+
     public async Task<bool> HasSchedulesInClassroomAsync(Guid id)
     {
         try
@@ -300,98 +105,6 @@ public class ClassroomService : IClassroomService
             throw new EntityServiceException("Classroom", $"HasSessionsInClassroom: {id}", "Error checking classroom dependencies", ex);
         }
     }
+
     #endregion
-
-    #region DeleteClassroomAsync
-    /// <summary>
-    /// Deletes a classroom by ID
-    /// </summary>
-    /// <param name="id">The ID of the classroom to delete</param>
-    /// <exception cref="EntityNotFoundException{TKey}">Thrown when classroom not found</exception>
-    /// <exception cref="EntityServiceException">Thrown when an error occurs during deletion</exception>
-    public async Task DeleteClassroomAsync(Guid id)
-    {
-        _logger.LogInformation("Deleting classroom with ID: {Id}", id);
-
-        try
-        {
-            var existingClassroom = await _classroomRepository.GetClassroomByIdAsync(id).ConfigureAwait(false);
-            if (existingClassroom == null)
-            {
-                _logger.LogWarning("Classroom deletion failed: Classroom with ID {Id} not found", id);
-                throw new EntityNotFoundException<Guid>("Classroom", id);
-            }
-
-            var result = await _classroomRepository.DeleteClassroomAsync(id).ConfigureAwait(false);
-            if (!result)
-            {
-                _logger.LogError("Classroom deletion failed: Failed to delete classroom with ID {Id}", id);
-                throw new EntityServiceException("Classroom", $"DeleteClassroom: {id}", "Failed to delete classroom");
-            }
-
-            var rowsAffected = await _classroomRepository.SaveChangesAsync().ConfigureAwait(false);
-            if (rowsAffected == 0)
-            {
-                _logger.LogWarning("Classroom deletion failed: Classroom with ID {Id} may have been deleted by another process", id);
-                throw new EntityServiceException("Classroom", $"DeleteClassroom: {id}", "Classroom may have been deleted by another process.");
-            }
-            _logger.LogInformation("Successfully deleted classroom with ID: {Id}", id);
-        }
-        catch (EntityNotFoundException<Guid>)
-        {
-            // Re-throw the specific exception for the controller to handle
-            throw;
-        }
-        catch (EntityServiceException)
-        {
-            throw;
-        }
-        catch (DbUpdateException ex) when (ExceptionHandlingHelper.IsForeignKeyViolation(ex))
-        {
-            var conflictType = ResolveDeleteConflictType(ex);
-            var conflictMessage = ResolveDeleteConflictMessage(conflictType);
-            _logger.LogWarning(ex, "Classroom deletion failed due to foreign key constraint: {Message}", conflictMessage);
-            throw new EntityConflictException("Classroom", conflictType, conflictMessage, ex);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while deleting classroom with ID {Id}", id);
-            throw ExceptionHandlingHelper.CreateServiceException("Classroom", $"DeleteClassroom: {id}", ex);
-        }
-    }
-    #endregion
-
-    #region DeleteClassroomByUuidAsync
-    public async Task DeleteClassroomByUuidAsync(Guid id)
-    {
-        var existingClassroom = await GetClassroomByUuidAsync(id).ConfigureAwait(false);
-        await DeleteClassroomAsync(existingClassroom!.Id).ConfigureAwait(false);
-    }
-    #endregion
-
-    private static string ResolveDeleteConflictType(DbUpdateException ex)
-    {
-        var message = ex.InnerException?.Message ?? ex.Message;
-        if (message.Contains("FK_Sessions_Classrooms_ActualRoomId", StringComparison.OrdinalIgnoreCase) || message.Contains("ActualRoomId", StringComparison.OrdinalIgnoreCase))
-        {
-            return "sessions";
-        }
-
-        if (message.Contains("FK_Schedules_Classrooms", StringComparison.OrdinalIgnoreCase) || message.Contains("Schedules", StringComparison.OrdinalIgnoreCase))
-        {
-            return "schedules";
-        }
-
-        return "dependencies";
-    }
-
-    private static string ResolveDeleteConflictMessage(string conflictType)
-    {
-        return conflictType switch
-        {
-            "sessions" => "Cannot delete: Classroom has sessions assigned. Remove sessions first.",
-            "schedules" => "Cannot delete: Classroom has schedules assigned. Remove schedules first.",
-            _ => "Cannot delete: Classroom has dependencies that prevent deletion.",
-        };
-    }
 }

--- a/attendance_monitoring/Services/CourseService.cs
+++ b/attendance_monitoring/Services/CourseService.cs
@@ -1,334 +1,93 @@
 using System.Security.Claims;
 using attendance_monitoring.Classes;
 using attendance_monitoring.Exceptions;
-using attendance_monitoring.Helpers;
 using attendance_monitoring.IRepository;
 using attendance_monitoring.IServices;
 using attendance_monitoring.Models.DTO.Request;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
+using attendance_monitoring.Services.Crud;
 
 namespace attendance_monitoring.Services;
 
 /// <summary>
-/// Service class for managing course-related operations
+/// Service class for managing course-related operations.
+/// Delegates CRUD operations to the generic CrudService; handles entity-specific
+/// user context validation and dependency checks via the course repository.
 /// </summary>
 public class CourseService : ICourseService
 {
+    private readonly ICrudService<Course, CreateCourse, UpdateCourse> _crudService;
     private readonly ICourseRepository _courseRepository;
     private readonly IUserContextService _userContextService;
     private readonly ILogger<CourseService> _logger;
 
-    /// <summary>
-    /// Initializes a new instance of the CourseService class
-    /// </summary>
-    /// <param name="courseRepository">Repository for course data operations</param>
-    /// <param name="userContextService">Service for managing user context and authorization</param>
-    /// <param name="logger">Logger for logging operations</param>
-    public CourseService(ICourseRepository courseRepository, IUserContextService userContextService, ILogger<CourseService> logger)
+    public CourseService(
+        ICrudService<Course, CreateCourse, UpdateCourse> crudService,
+        ICourseRepository courseRepository,
+        IUserContextService userContextService,
+        ILogger<CourseService> logger)
     {
-        _courseRepository = courseRepository ?? throw new ArgumentNullException(nameof(courseRepository));
-        _userContextService = userContextService ?? throw new ArgumentNullException(nameof(userContextService));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _crudService = crudService;
+        _courseRepository = courseRepository;
+        _userContextService = userContextService;
+        _logger = logger;
     }
 
-    #region Get Operations
-    #region GetAllCoursesAsync
-    /// <summary>
-    /// Retrieves all courses
-    /// </summary>
-    /// <returns>A collection of courses</returns>
+    #region Read Operations (delegated to CrudService)
+
     public async Task<IList<Course>> GetAllCoursesAsync()
     {
-        try
-        {
-            _logger.LogInformation("Retrieving all courses");
-            var courses = await _courseRepository.GetAllCoursesAsync().ConfigureAwait(false);
-            var allCoursesAsync = courses.ToList();
-            _logger.LogInformation("Successfully retrieved {Count} courses", allCoursesAsync.Count);
-            return allCoursesAsync;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while retrieving courses");
-            throw new EntityServiceException("Course", "GetAllCourses", "An error occurred while retrieving courses", ex);
-        }
+        var courses = await _crudService.GetAllAsync().ConfigureAwait(false);
+        return courses.ToList();
     }
-    #endregion
 
-    #region GetCourseByIdAsync
-    /// <summary>
-    /// Retrieves a specific course by ID
-    /// </summary>
-    /// <param name="id">The ID of the course to retrieve</param>
-    /// <returns>The course with the specified ID</returns>
-    /// <exception cref="T:attendance_monitoring.Exceptions.EntityNotFoundException{System.Int32}">Thrown when the course is not found</exception>
-    /// <exception cref="EntityServiceException">Thrown when an error occurs during retrieval</exception>
     public async Task<Course> GetCourseByIdAsync(Guid id)
     {
-        try
-        {
-            _logger.LogInformation("Retrieving course by ID: {Id}", id);
-            var course = await _courseRepository.GetCourseByIdAsync(id).ConfigureAwait(false);
-            if (course == null)
-            {
-                _logger.LogWarning("Course with ID {Id} not found", id);
-                throw new EntityNotFoundException<Guid>("Course", id);
-            }
-
-            _logger.LogInformation("Successfully retrieved course with ID: {Id}", id);
-            return course;
-        }
-        catch (EntityNotFoundException<Guid>)
-        {
-            // Re-throw EntityNotFoundException as-is
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while retrieving course with ID: {Id}", id);
-            throw new EntityServiceException("Course", $"GetCourseById: {id}", "An error occurred while retrieving the course", ex);
-        }
+        return await _crudService.GetByIdAsync(id).ConfigureAwait(false);
     }
-    #endregion
 
-    #region GetCourseByUuidAsync
     public async Task<Course> GetCourseByUuidAsync(Guid id)
     {
-        try
-        {
-            _logger.LogInformation("Retrieving course by UUID: {Id}", id);
-            var course = await _courseRepository.GetCourseByUuidAsync(id).ConfigureAwait(false);
-            if (course == null)
-            {
-                _logger.LogWarning("Course with UUID {Id} not found", id);
-                throw new EntityNotFoundException<Guid>("Course", id);
-            }
-
-            _logger.LogInformation("Successfully retrieved course with UUID: {Id}", id);
-            return course;
-        }
-        catch (EntityNotFoundException<Guid>)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while retrieving course with UUID: {Id}", id);
-            throw new EntityServiceException("Course", $"GetCourseByUuid: {id}", "An error occurred while retrieving the course", ex);
-        }
+        return await _crudService.GetByIdAsync(id).ConfigureAwait(false);
     }
-    #endregion
 
     #endregion
 
-    #region Create Operations
-    #region CreateCourseAsync
-    /// <summary>
-    /// Creates a new course record
-    /// </summary>
-    /// <param name="createCourse">The course data to create</param>
-    /// <param name="user">The claims principal of the current user</param>
-    /// <returns>The created course</returns>
-    /// <exception cref="EntityServiceException">Thrown when course creation fails</exception>
+    #region Mutation Operations (auth validation + CrudService delegation)
+
     public async Task<Course> CreateCourseAsync(CreateCourse createCourse, ClaimsPrincipal user)
     {
-        try
-        {
-            _logger.LogInformation("Creating new course with name: {CourseName}", createCourse.Name);
-
-            if (string.IsNullOrWhiteSpace(createCourse.Name))
-            {
-                _logger.LogWarning("Course creation failed: Course name is required");
-                throw new EntityServiceException("Course", "CreateCourse", "Course name is required");
-            }
-
-            var userId = await _userContextService.GetUserIdAsync(user).ConfigureAwait(false);
-            if (string.IsNullOrEmpty(userId))
-            {
-                _logger.LogWarning("Course creation failed: User ID not found in token");
-                throw new EntityServiceException("Course", "CreateCourse", "User ID not found in token");
-            }
-
-            var course = new Course
-            {
-                Name = createCourse.Name,
-                CreatedAt = DateTime.UtcNow,
-                UpdatedAt = DateTime.UtcNow
-            };
-
-            var createdCourse = await _courseRepository.CreateCourse(course).ConfigureAwait(false);
-            await _courseRepository.SaveChangesAsync().ConfigureAwait(false);
-
-            _logger.LogInformation("Successfully created course with ID: {Id} and name: {CourseName}", createdCourse.Id, createdCourse.Name);
-            return createdCourse;
-        }
-        catch (EntityServiceException)
-        {
-            // Re-throw EntityServiceException as-is
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while creating course with name: {CourseName}", createCourse.Name);
-            throw new EntityServiceException("Course", "CreateCourse", "An error occurred while creating the course", ex);
-        }
+        await ValidateUserContextAsync(user, "CreateCourse", null).ConfigureAwait(false);
+        return await _crudService.CreateAsync(createCourse).ConfigureAwait(false);
     }
-    #endregion
 
-    #endregion
-
-    #region Update Operations
-    #region UpdateCourseAsync
-    /// <summary>
-    /// Updates an existing course record
-    /// </summary>
-    /// <param name="id">The ID of the course to update</param>
-    /// <param name="updateCourse">The updated course data</param>
-    /// <param name="user">The claims principal of the current user</param>
-    /// <returns>The updated course</returns>
-    /// <exception cref="T:attendance_monitoring.Exceptions.EntityNotFoundException{System.Int32}">Thrown when the course is not found</exception>
-    /// <exception cref="EntityServiceException">Thrown when course update fails</exception>
     public async Task<Course> UpdateCourseAsync(Guid id, UpdateCourse updateCourse, ClaimsPrincipal user)
     {
-        try
-        {
-            _logger.LogInformation("Updating course with ID: {Id}", id);
-
-            // Additional validation for defense in depth
-            if (updateCourse == null)
-            {
-                _logger.LogWarning("Course update failed: Update course data is required");
-                throw new EntityServiceException("Course", $"UpdateCourse: {id}", "Update course data is required");
-            }
-
-            var userId = await _userContextService.GetUserIdAsync(user).ConfigureAwait(false);
-            if (string.IsNullOrEmpty(userId))
-            {
-                _logger.LogWarning("Course update failed: User ID not found in token");
-                throw new EntityServiceException("Course", $"UpdateCourse: {id}", "User ID not found in token");
-            }
-
-            var existingCourse = await _courseRepository.GetCourseByIdAsync(id).ConfigureAwait(false);
-            if (existingCourse == null)
-            {
-                _logger.LogWarning("Course update failed: Course with ID {Id} not found", id);
-                throw new EntityNotFoundException<Guid>("Course", id);
-            }
-
-            if (!string.IsNullOrEmpty(updateCourse.Name))
-            {
-                existingCourse.Name = updateCourse.Name;
-            }
-
-            existingCourse.UpdatedAt = DateTime.UtcNow;
-
-            var updatedCourse = await _courseRepository.UpdateCourseAsync(existingCourse).ConfigureAwait(false);
-            await _courseRepository.SaveChangesAsync().ConfigureAwait(false);
-
-            _logger.LogInformation("Successfully updated course with ID: {Id}", id);
-            return updatedCourse;
-        }
-        catch (EntityNotFoundException<Guid>)
-        {
-            // Re-throw EntityNotFoundException as-is
-            throw;
-        }
-        catch (EntityServiceException)
-        {
-            // Re-throw EntityServiceException as-is
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while updating course with ID: {Id}", id);
-            throw new EntityServiceException("Course", $"UpdateCourse: {id}", "An error occurred while updating the course", ex);
-        }
+        await ValidateUserContextAsync(user, "UpdateCourse", id).ConfigureAwait(false);
+        return await _crudService.UpdateAsync(id, updateCourse).ConfigureAwait(false);
     }
-    #endregion
 
-    #region UpdateCourseByUuidAsync
     public async Task<Course> UpdateCourseByUuidAsync(Guid id, UpdateCourse updateCourse, ClaimsPrincipal user)
     {
-        var existingCourse = await GetCourseByUuidAsync(id).ConfigureAwait(false);
-        return await UpdateCourseAsync(existingCourse.Id, updateCourse, user).ConfigureAwait(false);
+        await ValidateUserContextAsync(user, "UpdateCourse", id).ConfigureAwait(false);
+        return await _crudService.UpdateAsync(id, updateCourse).ConfigureAwait(false);
     }
-    #endregion
 
-    #endregion
-
-    #region Delete Operations
-    #region DeleteCourseAsync
-    /// <summary>
-    /// Deletes a course by ID
-    /// </summary>
-    /// <param name="id">The ID of the course to delete</param>
-    /// <param name="user">The claims principal of the current user</param>
-    /// <exception cref="T:attendance_monitoring.Exceptions.EntityNotFoundException{System.Int32}">Thrown when the course is not found</exception>
-    /// <exception cref="EntityServiceException">Thrown when course deletion fails</exception>
     public async Task DeleteCourseAsync(Guid id, ClaimsPrincipal user)
     {
-        try
-        {
-            _logger.LogInformation("Deleting course with ID: {Id}", id);
-
-            var userId = await _userContextService.GetUserIdAsync(user).ConfigureAwait(false);
-            if (string.IsNullOrEmpty(userId))
-            {
-                _logger.LogWarning("Course deletion failed: User ID not found in token");
-                throw new EntityServiceException("Course", $"DeleteCourse: {id}", "User ID not found in token");
-            }
-
-            var existingCourse = await _courseRepository.GetCourseByIdAsync(id).ConfigureAwait(false);
-            if (existingCourse == null)
-            {
-                _logger.LogWarning("Course deletion failed: Course with ID {Id} not found", id);
-                throw new EntityNotFoundException<Guid>("Course", id);
-            }
-
-            var result = await _courseRepository.DeleteCourseAsync(id).ConfigureAwait(false);
-            if (!result)
-            {
-                _logger.LogError("Course deletion failed: Failed to delete course with ID {Id}", id);
-                throw new EntityServiceException("Course", $"DeleteCourse: {id}", "Failed to delete course");
-            }
-
-            await _courseRepository.SaveChangesAsync().ConfigureAwait(false);
-            _logger.LogInformation("Successfully deleted course with ID: {Id}", id);
-        }
-        catch (EntityNotFoundException<Guid>)
-        {
-            // Re-throw EntityNotFoundException as-is
-            throw;
-        }
-        catch (EntityServiceException)
-        {
-            // Re-throw EntityServiceException as-is
-            throw;
-        }
-        catch (DbUpdateException ex) when (ExceptionHandlingHelper.IsForeignKeyViolation(ex))
-        {
-            var conflictMessage = ResolveDeleteConflictMessage(ex);
-            _logger.LogWarning(ex, "Course deletion failed due to foreign key constraint: {Message}", conflictMessage);
-            throw new EntityConflictException("Course", "sections", conflictMessage, ex);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while deleting course with ID: {Id}", id);
-            throw new EntityServiceException("Course", $"DeleteCourse: {id}", "An error occurred while deleting the course", ex);
-        }
+        await ValidateUserContextAsync(user, "DeleteCourse", id).ConfigureAwait(false);
+        await _crudService.DeleteAsync(id).ConfigureAwait(false);
     }
-    #endregion
 
-    #region DeleteCourseByUuidAsync
     public async Task DeleteCourseByUuidAsync(Guid id, ClaimsPrincipal user)
     {
-        var existingCourse = await GetCourseByUuidAsync(id).ConfigureAwait(false);
-        await DeleteCourseAsync(existingCourse.Id, user).ConfigureAwait(false);
+        await ValidateUserContextAsync(user, "DeleteCourse", id).ConfigureAwait(false);
+        await _crudService.DeleteAsync(id).ConfigureAwait(false);
     }
+
     #endregion
 
-    #region Dependency Check Operations
+    #region Dependency Check Operations (entity-specific)
+
     public async Task<bool> HasSectionsInCourseAsync(Guid id)
     {
         try
@@ -344,17 +103,20 @@ public class CourseService : ICourseService
             throw new EntityServiceException("Course", $"HasSectionsInCourse: {id}", "Error checking course dependencies", ex);
         }
     }
+
     #endregion
 
-    private static string ResolveDeleteConflictMessage(DbUpdateException ex)
-    {
-        var message = ex.InnerException?.Message ?? ex.Message;
-        if (message.Contains("FK_Sections_Courses", StringComparison.OrdinalIgnoreCase) || message.Contains("Sections", StringComparison.OrdinalIgnoreCase))
-        {
-            return "Cannot delete: Course has sections assigned. Remove sections first.";
-        }
+    #region Helpers
 
-        return "Cannot delete: Course has dependencies that prevent deletion.";
+    private async Task ValidateUserContextAsync(ClaimsPrincipal user, string operation, Guid? courseId)
+    {
+        var userId = await _userContextService.GetUserIdAsync(user).ConfigureAwait(false);
+        if (string.IsNullOrEmpty(userId))
+        {
+            var context = courseId.HasValue ? $" for course {courseId}" : "";
+            _logger.LogWarning("{Operation} failed{Context}: User ID not found in token", operation, context);
+            throw new EntityServiceException("Course", $"{operation}{context}", "User ID not found in token");
+        }
     }
 
     #endregion

--- a/attendance_monitoring/Services/Crud/ClassroomConfig.cs
+++ b/attendance_monitoring/Services/Crud/ClassroomConfig.cs
@@ -1,0 +1,74 @@
+using attendance_monitoring.Classes;
+using attendance_monitoring.Helpers;
+using attendance_monitoring.IRepository;
+using attendance_monitoring.Models.DTO.Request;
+using Microsoft.EntityFrameworkCore;
+
+namespace attendance_monitoring.Services.Crud;
+
+/// <summary>
+/// CRUD configuration for the Classroom entity.
+/// </summary>
+public static class ClassroomConfig
+{
+    public static CrudServiceConfig<Classroom, CreateClassroom, UpdateClassroom> Create(
+        IClassroomRepository classroomRepository)
+    {
+        return new CrudServiceConfig<Classroom, CreateClassroom, UpdateClassroom>
+        {
+            EntityName = "Classroom",
+
+            CreateUniquenessChecks =
+            [
+                new UniquenessCheck<CreateClassroom>
+                {
+                    FieldName = "Name",
+                    ValueSelector = dto => dto.Name,
+                    ExistsAsync = async name =>
+                        await classroomRepository.GetClassroomByNameAsync(name).ConfigureAwait(false) != null
+                }
+            ],
+
+            UpdateUniquenessChecks =
+            [
+                new UpdateUniquenessCheck<Classroom, UpdateClassroom>
+                {
+                    FieldName = "Name",
+                    ValueSelector = dto => dto.Name,
+                    CurrentValueSelector = entity => entity.Name,
+                    FindByUniqueFieldAsync = async name =>
+                        await classroomRepository.GetClassroomByNameAsync(name).ConfigureAwait(false)
+                }
+            ],
+
+            MapToEntity = dto => new Classroom
+            {
+                Id = Guid.NewGuid(),
+                Name = dto.Name,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            },
+
+            ApplyUpdate = (dto, entity) =>
+            {
+                if (!string.IsNullOrEmpty(dto.Name))
+                    entity.Name = dto.Name;
+                entity.UpdatedAt = DateTime.UtcNow;
+            },
+
+            ResolveUniqueConstraintViolation = _ => ("Name", ""),
+
+            ResolveForeignKeyViolation = ex =>
+            {
+                var message = ex.InnerException?.Message ?? ex.Message;
+                if (message.Contains("FK_Sessions_Classrooms_ActualRoomId", StringComparison.OrdinalIgnoreCase)
+                    || message.Contains("ActualRoomId", StringComparison.OrdinalIgnoreCase))
+                    return ("sessions", "Cannot delete: Classroom has sessions assigned. Remove sessions first.");
+                if (message.Contains("FK_Schedules_Classrooms", StringComparison.OrdinalIgnoreCase)
+                    || message.Contains("Schedules", StringComparison.OrdinalIgnoreCase))
+                    return ("schedules", "Cannot delete: Classroom has schedules assigned. Remove schedules first.");
+                return null;
+            }
+        };
+    }
+}

--- a/attendance_monitoring/Services/Crud/CourseConfig.cs
+++ b/attendance_monitoring/Services/Crud/CourseConfig.cs
@@ -1,4 +1,5 @@
 using attendance_monitoring.Classes;
+using attendance_monitoring.IRepository;
 using attendance_monitoring.Models.DTO.Request;
 
 namespace attendance_monitoring.Services.Crud;
@@ -8,15 +9,35 @@ namespace attendance_monitoring.Services.Crud;
 /// </summary>
 public static class CourseConfig
 {
-    public static CrudServiceConfig<Course, CreateCourse, UpdateCourse> Create()
+    public static CrudServiceConfig<Course, CreateCourse, UpdateCourse> Create(
+        ICourseRepository courseRepository)
     {
         return new CrudServiceConfig<Course, CreateCourse, UpdateCourse>
         {
             EntityName = "Course",
 
-            CreateUniquenessChecks = [],
+            CreateUniquenessChecks =
+            [
+                new UniquenessCheck<CreateCourse>
+                {
+                    FieldName = "Name",
+                    ValueSelector = dto => dto.Name,
+                    ExistsAsync = async name =>
+                        await courseRepository.GetCourseByNameAsync(name).ConfigureAwait(false) != null
+                }
+            ],
 
-            UpdateUniquenessChecks = [],
+            UpdateUniquenessChecks =
+            [
+                new UpdateUniquenessCheck<Course, UpdateCourse>
+                {
+                    FieldName = "Name",
+                    ValueSelector = dto => dto.Name,
+                    CurrentValueSelector = entity => entity.Name,
+                    FindByUniqueFieldAsync = async name =>
+                        await courseRepository.GetCourseByNameAsync(name).ConfigureAwait(false)
+                }
+            ],
 
             MapToEntity = dto => new Course
             {
@@ -33,7 +54,7 @@ public static class CourseConfig
                 entity.UpdatedAt = DateTime.UtcNow;
             },
 
-            ResolveUniqueConstraintViolation = null,
+            ResolveUniqueConstraintViolation = _ => ("Name", ""),
 
             ResolveForeignKeyViolation = ex =>
             {

--- a/attendance_monitoring/Services/Crud/CourseConfig.cs
+++ b/attendance_monitoring/Services/Crud/CourseConfig.cs
@@ -1,0 +1,48 @@
+using attendance_monitoring.Classes;
+using attendance_monitoring.Models.DTO.Request;
+
+namespace attendance_monitoring.Services.Crud;
+
+/// <summary>
+/// CRUD configuration for the Course entity.
+/// </summary>
+public static class CourseConfig
+{
+    public static CrudServiceConfig<Course, CreateCourse, UpdateCourse> Create()
+    {
+        return new CrudServiceConfig<Course, CreateCourse, UpdateCourse>
+        {
+            EntityName = "Course",
+
+            CreateUniquenessChecks = [],
+
+            UpdateUniquenessChecks = [],
+
+            MapToEntity = dto => new Course
+            {
+                Id = Guid.NewGuid(),
+                Name = dto.Name,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            },
+
+            ApplyUpdate = (dto, entity) =>
+            {
+                if (!string.IsNullOrEmpty(dto.Name))
+                    entity.Name = dto.Name;
+                entity.UpdatedAt = DateTime.UtcNow;
+            },
+
+            ResolveUniqueConstraintViolation = null,
+
+            ResolveForeignKeyViolation = ex =>
+            {
+                var message = ex.InnerException?.Message ?? ex.Message;
+                if (message.Contains("FK_Sections_Courses", StringComparison.OrdinalIgnoreCase)
+                    || message.Contains("Sections", StringComparison.OrdinalIgnoreCase))
+                    return ("sections", "Cannot delete: Course has sections assigned. Remove sections first.");
+                return null;
+            }
+        };
+    }
+}

--- a/attendance_monitoring/Services/Crud/CrudService.cs
+++ b/attendance_monitoring/Services/Crud/CrudService.cs
@@ -1,0 +1,292 @@
+using attendance_monitoring.Exceptions;
+using attendance_monitoring.Helpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ValidationException = attendance_monitoring.Exceptions.ValidationException;
+
+namespace attendance_monitoring.Services.Crud;
+
+/// <summary>
+/// Generic CRUD service that implements the common try-catch-log-rethrow pattern
+/// for entity create, read, update, and delete operations. Entity-specific behavior
+/// (uniqueness checks, entity mapping, FK conflict resolution) is driven by
+/// <see cref="CrudServiceConfig{TEntity,TCreate,TUpdate}"/>.
+/// </summary>
+public class CrudService<TEntity, TCreate, TUpdate> : ICrudService<TEntity, TCreate, TUpdate>
+    where TEntity : class
+{
+    private readonly IGenericCrudRepository<TEntity> _repository;
+    private readonly CrudServiceConfig<TEntity, TCreate, TUpdate> _config;
+    private readonly ILogger<CrudService<TEntity, TCreate, TUpdate>> _logger;
+
+    public CrudService(
+        IGenericCrudRepository<TEntity> repository,
+        CrudServiceConfig<TEntity, TCreate, TUpdate> config,
+        ILogger<CrudService<TEntity, TCreate, TUpdate>> logger)
+    {
+        _repository = repository;
+        _config = config;
+        _logger = logger;
+    }
+
+    #region GetAllAsync
+
+    public async Task<IEnumerable<TEntity>> GetAllAsync()
+    {
+        _logger.LogInformation("Retrieving all {EntityName}s", _config.EntityName);
+        try
+        {
+            var entities = await _repository.GetAllAsync().ConfigureAwait(false);
+            var list = entities.ToList();
+            _logger.LogInformation("Successfully retrieved {Count} {EntityName}s", list.Count, _config.EntityName);
+            return list;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error occurred while retrieving all {EntityName}s", _config.EntityName);
+            throw new EntityServiceException(_config.EntityName, $"GetAll{_config.EntityName}",
+                $"An error occurred while retrieving {_config.EntityName.ToLowerInvariant()}s", ex);
+        }
+    }
+
+    #endregion
+
+    #region GetByIdAsync
+
+    public async Task<TEntity> GetByIdAsync(Guid id)
+    {
+        _logger.LogInformation("Retrieving {EntityName} by ID: {Id}", _config.EntityName, id);
+        try
+        {
+            var entity = await _repository.GetByIdAsync(id).ConfigureAwait(false);
+            if (entity == null)
+            {
+                _logger.LogWarning("{EntityName} with ID {Id} not found", _config.EntityName, id);
+                throw new EntityNotFoundException<Guid>(_config.EntityName, id);
+            }
+
+            _logger.LogInformation("Successfully retrieved {EntityName} with ID: {Id}", _config.EntityName, id);
+            return entity;
+        }
+        catch (EntityNotFoundException<Guid>)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error occurred while retrieving {EntityName} with ID {Id}", _config.EntityName, id);
+            throw new EntityServiceException(_config.EntityName, $"Get{_config.EntityName}ById: {id}",
+                $"An error occurred while retrieving the {_config.EntityName.ToLowerInvariant()}", ex);
+        }
+    }
+
+    #endregion
+
+    #region CreateAsync
+
+    public async Task<TEntity> CreateAsync(TCreate createDto)
+    {
+        _logger.LogInformation("Creating new {EntityName}", _config.EntityName);
+        try
+        {
+            // Run uniqueness checks
+            foreach (var check in _config.CreateUniquenessChecks)
+            {
+                var value = check.ValueSelector(createDto);
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    _logger.LogWarning("{EntityName} creation failed: {FieldName} is required", _config.EntityName, check.FieldName);
+                    throw new ValidationException($"{check.FieldName} is required");
+                }
+
+                if (await check.ExistsAsync(value).ConfigureAwait(false))
+                {
+                    _logger.LogWarning("{EntityName} creation failed: {FieldName} {Value} already exists",
+                        _config.EntityName, check.FieldName, value);
+                    throw new EntityAlreadyExistsException<string>(_config.EntityName, check.FieldName, value);
+                }
+            }
+
+            // Map DTO to entity
+            var entity = _config.MapToEntity(createDto);
+
+            // Persist
+            var created = await _repository.CreateAsync(entity).ConfigureAwait(false);
+            await _repository.SaveChangesAsync().ConfigureAwait(false);
+
+            _logger.LogInformation("Successfully created {EntityName} with ID: {Id}", _config.EntityName,
+                GetEntityId(created));
+            return created;
+        }
+        catch (ValidationException)
+        {
+            throw;
+        }
+        catch (EntityAlreadyExistsException<string>)
+        {
+            throw;
+        }
+        catch (DbUpdateException ex) when (ExceptionHandlingHelper.IsUniqueConstraintViolation(ex))
+        {
+            var resolved = _config.ResolveUniqueConstraintViolation?.Invoke(ex);
+            var fieldName = resolved?.FieldName ?? "field";
+            var fieldValue = resolved?.FieldValue ?? "value";
+            _logger.LogWarning(ex, "{EntityName} creation failed due to unique constraint violation: {FieldName} {FieldValue} already exists",
+                _config.EntityName, fieldName, fieldValue);
+            throw new EntityAlreadyExistsException<string>(_config.EntityName, fieldName, fieldValue);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error occurred while creating {EntityName}", _config.EntityName);
+            throw ExceptionHandlingHelper.CreateServiceException(_config.EntityName, $"Create{_config.EntityName}", ex);
+        }
+    }
+
+    #endregion
+
+    #region UpdateAsync
+
+    public async Task<TEntity> UpdateAsync(Guid id, TUpdate updateDto)
+    {
+        _logger.LogInformation("Updating {EntityName} with ID: {Id}", _config.EntityName, id);
+        try
+        {
+            // Load tracked entity
+            var existing = await _repository.GetByIdTrackedAsync(id).ConfigureAwait(false);
+            if (existing == null)
+            {
+                _logger.LogWarning("{EntityName} update failed: {EntityName} with ID {Id} not found", _config.EntityName, id);
+                throw new EntityNotFoundException<Guid>(_config.EntityName, id);
+            }
+
+            // Run update uniqueness checks
+            var entityId = GetEntityId(existing);
+            foreach (var check in _config.UpdateUniquenessChecks)
+            {
+                var newValue = check.ValueSelector(updateDto);
+                if (string.IsNullOrEmpty(newValue))
+                    continue;
+
+                var currentValue = check.CurrentValueSelector(existing);
+                if (newValue.Equals(currentValue, StringComparison.Ordinal))
+                    continue;
+
+                var duplicate = await check.FindByUniqueFieldAsync(newValue).ConfigureAwait(false);
+                if (duplicate != null && !GetEntityId(duplicate).Equals(entityId))
+                {
+                    _logger.LogWarning("{EntityName} update failed: {FieldName} {Value} already exists",
+                        _config.EntityName, check.FieldName, newValue);
+                    throw new EntityAlreadyExistsException<string>(_config.EntityName, check.FieldName, newValue);
+                }
+            }
+
+            // Apply update
+            _config.ApplyUpdate(updateDto, existing);
+
+            // Persist
+            _repository.Update(existing);
+            var rowsAffected = await _repository.SaveChangesAsync().ConfigureAwait(false);
+
+            if (rowsAffected == 0)
+            {
+                _logger.LogWarning("{EntityName} update failed: {EntityName} with ID {Id} may have been updated by another process",
+                    _config.EntityName, id);
+                throw new EntityServiceException(_config.EntityName, $"Update{_config.EntityName}: {id}",
+                    $"{_config.EntityName} may have been updated by another process. Please try again.");
+            }
+
+            _logger.LogInformation("Successfully updated {EntityName} with ID: {Id}", _config.EntityName, id);
+            return existing;
+        }
+        catch (EntityNotFoundException<Guid>)
+        {
+            throw;
+        }
+        catch (EntityAlreadyExistsException<string>)
+        {
+            throw;
+        }
+        catch (EntityServiceException)
+        {
+            throw;
+        }
+        catch (DbUpdateException ex) when (ExceptionHandlingHelper.IsUniqueConstraintViolation(ex))
+        {
+            var resolved = _config.ResolveUniqueConstraintViolation?.Invoke(ex);
+            var fieldName = resolved?.FieldName ?? "field";
+            var fieldValue = resolved?.FieldValue ?? "value";
+            _logger.LogWarning(ex, "{EntityName} update failed due to unique constraint violation: {FieldName} {FieldValue} already exists",
+                _config.EntityName, fieldName, fieldValue);
+            throw new EntityAlreadyExistsException<string>(_config.EntityName, fieldName, fieldValue);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error occurred while updating {EntityName} with ID {Id}", _config.EntityName, id);
+            throw ExceptionHandlingHelper.CreateServiceException(_config.EntityName, $"Update{_config.EntityName}: {id}", ex);
+        }
+    }
+
+    #endregion
+
+    #region DeleteAsync
+
+    public async Task DeleteAsync(Guid id)
+    {
+        _logger.LogInformation("Deleting {EntityName} with ID: {Id}", _config.EntityName, id);
+        try
+        {
+            var existing = await _repository.GetByIdAsync(id).ConfigureAwait(false);
+            if (existing == null)
+            {
+                _logger.LogWarning("{EntityName} deletion failed: {EntityName} with ID {Id} not found", _config.EntityName, id);
+                throw new EntityNotFoundException<Guid>(_config.EntityName, id);
+            }
+
+            _repository.Delete(existing);
+            var rowsAffected = await _repository.SaveChangesAsync().ConfigureAwait(false);
+
+            if (rowsAffected == 0)
+            {
+                _logger.LogWarning("{EntityName} deletion failed: {EntityType} with ID {Id} may have been deleted by another process",
+                    _config.EntityName, _config.EntityName, id);
+                throw new EntityServiceException(_config.EntityName, $"Delete{_config.EntityName}: {id}",
+                    $"{_config.EntityName} may have been deleted by another process.");
+            }
+
+            _logger.LogInformation("Successfully deleted {EntityName} with ID: {Id}", _config.EntityName, id);
+        }
+        catch (EntityNotFoundException<Guid>)
+        {
+            throw;
+        }
+        catch (EntityServiceException)
+        {
+            throw;
+        }
+        catch (DbUpdateException ex) when (ExceptionHandlingHelper.IsForeignKeyViolation(ex))
+        {
+            var resolved = _config.ResolveForeignKeyViolation?.Invoke(ex);
+            var conflictType = resolved?.ConflictType ?? "dependencies";
+            var conflictMessage = resolved?.Message ?? $"Cannot delete: {_config.EntityName} has dependencies that prevent deletion.";
+            _logger.LogWarning(ex, "{EntityName} deletion failed due to foreign key constraint: {Message}", _config.EntityName, conflictMessage);
+            throw new EntityConflictException(_config.EntityName, conflictType, conflictMessage, ex);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error occurred while deleting {EntityName} with ID {Id}", _config.EntityName, id);
+            throw ExceptionHandlingHelper.CreateServiceException(_config.EntityName, $"Delete{_config.EntityName}: {id}", ex);
+        }
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static object GetEntityId(TEntity entity)
+    {
+        var prop = typeof(TEntity).GetProperty("Id");
+        return prop?.GetValue(entity) ?? "(unknown)";
+    }
+
+    #endregion
+}

--- a/attendance_monitoring/Services/Crud/CrudServiceConfig.cs
+++ b/attendance_monitoring/Services/Crud/CrudServiceConfig.cs
@@ -1,0 +1,105 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace attendance_monitoring.Services.Crud;
+
+/// <summary>
+/// Defines a uniqueness check for a field during entity creation or update.
+/// </summary>
+/// <typeparam name="TCreate">The create request DTO type.</typeparam>
+public class UniquenessCheck<TCreate>
+{
+    /// <summary>
+    /// The field name used in error messages (e.g., "Name", "Code").
+    /// </summary>
+    public required string FieldName { get; init; }
+
+    /// <summary>
+    /// Extracts the field value from the create DTO.
+    /// </summary>
+    public required Func<TCreate, string?> ValueSelector { get; init; }
+
+    /// <summary>
+    /// Checks if an entity with the given field value already exists.
+    /// Returns the existing entity if found; otherwise, null.
+    /// </summary>
+    public required Func<string, Task<bool>> ExistsAsync { get; init; }
+}
+
+/// <summary>
+/// Configuration for a generic CRUD module. Defines entity-specific behavior
+/// (uniqueness checks, entity mapping, FK conflict resolution) while the
+/// generic module handles the common try-catch-log-rethrow pattern.
+/// </summary>
+/// <typeparam name="TEntity">The domain entity type (e.g., Classroom, Subject).</typeparam>
+/// <typeparam name="TCreate">The create request DTO type.</typeparam>
+/// <typeparam name="TUpdate">The update request DTO type.</typeparam>
+public class CrudServiceConfig<TEntity, TCreate, TUpdate>
+{
+    /// <summary>
+    /// Entity name used in log messages and exception messages (e.g., "Classroom").
+    /// </summary>
+    public required string EntityName { get; init; }
+
+    /// <summary>
+    /// Uniqueness checks to run before create. Each check verifies a field is unique.
+    /// </summary>
+    public required IReadOnlyList<UniquenessCheck<TCreate>> CreateUniquenessChecks { get; init; }
+
+    /// <summary>
+    /// Uniqueness checks to run before update. The TUpdate delegate receives both
+    /// the update DTO and the existing entity to determine the field value.
+    /// </summary>
+    public IReadOnlyList<UpdateUniquenessCheck<TEntity, TUpdate>> UpdateUniquenessChecks { get; init; } = [];
+
+    /// <summary>
+    /// Maps a create DTO to a new entity. Sets all fields including CreatedAt/UpdatedAt.
+    /// </summary>
+    public required Func<TCreate, TEntity> MapToEntity { get; init; }
+
+    /// <summary>
+    /// Applies update DTO fields to an existing entity. Only sets non-null fields.
+    /// Should also update UpdatedAt.
+    /// </summary>
+    public required Action<TUpdate, TEntity> ApplyUpdate { get; init; }
+
+    /// <summary>
+    /// Resolves a DbUpdateException (typically from unique constraint violation during save)
+    /// into a field name and value for the EntityAlreadyExistsException message.
+    /// Returns null if the exception is not a recognized constraint violation.
+    /// </summary>
+    public Func<DbUpdateException, (string FieldName, string FieldValue)?>? ResolveUniqueConstraintViolation { get; init; }
+
+    /// <summary>
+    /// Resolves a DbUpdateException (typically from FK constraint violation on delete)
+    /// into a conflict type and user-friendly message.
+    /// Returns null if the exception is not a recognized FK violation.
+    /// </summary>
+    public Func<DbUpdateException, (string ConflictType, string Message)?>? ResolveForeignKeyViolation { get; init; }
+}
+
+/// <summary>
+/// Defines a uniqueness check for a field during entity update.
+/// </summary>
+public class UpdateUniquenessCheck<TEntity, TUpdate>
+{
+    /// <summary>
+    /// The field name used in error messages (e.g., "Name", "Code").
+    /// </summary>
+    public required string FieldName { get; init; }
+
+    /// <summary>
+    /// Extracts the field value from the update DTO. Returns null if the field is not being updated.
+    /// </summary>
+    public required Func<TUpdate, string?> ValueSelector { get; init; }
+
+    /// <summary>
+    /// Extracts the current field value from the existing entity for comparison.
+    /// </summary>
+    public required Func<TEntity, string> CurrentValueSelector { get; init; }
+
+    /// <summary>
+    /// Finds an entity by the given field value. Returns the entity if found; otherwise, null.
+    /// Used during update to check for duplicates while excluding the current entity by ID.
+    /// </summary>
+    public required Func<string, Task<TEntity?>> FindByUniqueFieldAsync { get; init; }
+}

--- a/attendance_monitoring/Services/Crud/GenericCrudRepository.cs
+++ b/attendance_monitoring/Services/Crud/GenericCrudRepository.cs
@@ -1,0 +1,58 @@
+using attendance_monitoring.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace attendance_monitoring.Services.Crud;
+
+/// <summary>
+/// Generic EF Core repository implementation for CRUD operations.
+/// Uses ApplicationDbContext directly with DbSet access.
+/// </summary>
+public class GenericCrudRepository<TEntity> : IGenericCrudRepository<TEntity>
+    where TEntity : class
+{
+    private readonly ApplicationDbContext _context;
+    private readonly DbSet<TEntity> _dbSet;
+
+    public GenericCrudRepository(ApplicationDbContext context)
+    {
+        _context = context;
+        _dbSet = context.Set<TEntity>();
+    }
+
+    public async Task<IEnumerable<TEntity>> GetAllAsync()
+    {
+        return await _dbSet.AsNoTracking().ToListAsync().ConfigureAwait(false);
+    }
+
+    public async Task<TEntity?> GetByIdAsync(Guid id)
+    {
+        return await _dbSet.FindAsync(id).ConfigureAwait(false);
+    }
+
+    public async Task<TEntity?> GetByIdTrackedAsync(Guid id)
+    {
+        // FindAsync uses the change tracker by default, so this returns a tracked entity
+        return await _dbSet.FindAsync(id).ConfigureAwait(false);
+    }
+
+    public async Task<TEntity> CreateAsync(TEntity entity)
+    {
+        var entry = await _dbSet.AddAsync(entity).ConfigureAwait(false);
+        return entry.Entity;
+    }
+
+    public void Update(TEntity entity)
+    {
+        _dbSet.Update(entity);
+    }
+
+    public void Delete(TEntity entity)
+    {
+        _dbSet.Remove(entity);
+    }
+
+    public async Task<int> SaveChangesAsync()
+    {
+        return await _context.SaveChangesAsync().ConfigureAwait(false);
+    }
+}

--- a/attendance_monitoring/Services/Crud/ICrudService.cs
+++ b/attendance_monitoring/Services/Crud/ICrudService.cs
@@ -1,0 +1,55 @@
+namespace attendance_monitoring.Services.Crud;
+
+/// <summary>
+/// Generic CRUD service interface. Provides standard create, read, update, and delete
+/// operations for any entity type. Entity-specific behavior (uniqueness checks, FK conflict
+/// messages, entity mapping) is configured via <see cref="CrudServiceConfig{TEntity,TCreate,TUpdate}"/>.
+/// </summary>
+/// <typeparam name="TEntity">The domain entity type.</typeparam>
+/// <typeparam name="TCreate">The create request DTO type.</typeparam>
+/// <typeparam name="TUpdate">The update request DTO type.</typeparam>
+public interface ICrudService<TEntity, in TCreate, in TUpdate>
+{
+    /// <summary>
+    /// Retrieves all entities.
+    /// </summary>
+    Task<IEnumerable<TEntity>> GetAllAsync();
+
+    /// <summary>
+    /// Retrieves an entity by its ID.
+    /// </summary>
+    /// <param name="id">The entity ID.</param>
+    /// <returns>The entity if found.</returns>
+    /// <exception cref="Exceptions.EntityNotFoundException{Guid}">Thrown when the entity is not found.</exception>
+    Task<TEntity> GetByIdAsync(Guid id);
+
+    /// <summary>
+    /// Creates a new entity after validating uniqueness constraints.
+    /// </summary>
+    /// <param name="createDto">The create request DTO.</param>
+    /// <returns>The created entity.</returns>
+    /// <exception cref="Exceptions.ValidationException">Thrown when a required field is missing.</exception>
+    /// <exception cref="Exceptions.EntityAlreadyExistsException{string}">Thrown when a unique field value already exists.</exception>
+    /// <exception cref="Exceptions.EntityServiceException">Thrown when an unexpected error occurs.</exception>
+    Task<TEntity> CreateAsync(TCreate createDto);
+
+    /// <summary>
+    /// Updates an existing entity after validating uniqueness constraints.
+    /// </summary>
+    /// <param name="id">The entity ID.</param>
+    /// <param name="updateDto">The update request DTO.</param>
+    /// <returns>The updated entity.</returns>
+    /// <exception cref="Exceptions.EntityNotFoundException{Guid}">Thrown when the entity is not found.</exception>
+    /// <exception cref="Exceptions.EntityAlreadyExistsException{string}">Thrown when a unique field value already exists.</exception>
+    /// <exception cref="Exceptions.EntityServiceException">Thrown when an unexpected error occurs.</exception>
+    Task<TEntity> UpdateAsync(Guid id, TUpdate updateDto);
+
+    /// <summary>
+    /// Deletes an entity by its ID.
+    /// </summary>
+    /// <param name="id">The entity ID.</param>
+    /// <exception cref="Exceptions.EntityNotFoundException{Guid}">Thrown when the entity is not found.</exception>
+    /// <exception cref="Exceptions.EntityConflictException">Thrown when FK constraints prevent deletion.</exception>
+    /// <exception cref="Exceptions.EntityServiceException">Thrown when an unexpected error occurs.</exception>
+    Task DeleteAsync(Guid id);
+}

--- a/attendance_monitoring/Services/Crud/IGenericCrudRepository.cs
+++ b/attendance_monitoring/Services/Crud/IGenericCrudRepository.cs
@@ -1,0 +1,44 @@
+namespace attendance_monitoring.Services.Crud;
+
+/// <summary>
+/// Generic repository interface for CRUD operations. Abstracts EF Core DbContext access
+/// behind a minimal interface that the generic CrudService depends on.
+/// </summary>
+/// <typeparam name="TEntity">The domain entity type.</typeparam>
+public interface IGenericCrudRepository<TEntity> where TEntity : class
+{
+    /// <summary>
+    /// Retrieves all entities (no tracking).
+    /// </summary>
+    Task<IEnumerable<TEntity>> GetAllAsync();
+
+    /// <summary>
+    /// Retrieves an entity by its ID (no tracking).
+    /// </summary>
+    Task<TEntity?> GetByIdAsync(Guid id);
+
+    /// <summary>
+    /// Retrieves an entity by its ID with change tracking enabled.
+    /// </summary>
+    Task<TEntity?> GetByIdTrackedAsync(Guid id);
+
+    /// <summary>
+    /// Adds a new entity to the context.
+    /// </summary>
+    Task<TEntity> CreateAsync(TEntity entity);
+
+    /// <summary>
+    /// Marks an entity as modified in the context.
+    /// </summary>
+    void Update(TEntity entity);
+
+    /// <summary>
+    /// Removes an entity from the context.
+    /// </summary>
+    void Delete(TEntity entity);
+
+    /// <summary>
+    /// Saves all changes to the database.
+    /// </summary>
+    Task<int> SaveChangesAsync();
+}

--- a/attendance_monitoring/Services/Crud/SectionConfig.cs
+++ b/attendance_monitoring/Services/Crud/SectionConfig.cs
@@ -1,0 +1,55 @@
+using attendance_monitoring.Classes;
+
+namespace attendance_monitoring.Services.Crud;
+
+/// <summary>
+/// CRUD configuration for the Section entity.
+/// Uses Section as both TCreate and TUpdate since the controller maps the DTO to an entity
+/// before calling the service.
+/// </summary>
+public static class SectionConfig
+{
+    public static CrudServiceConfig<Section, Section, Section> Create()
+    {
+        return new CrudServiceConfig<Section, Section, Section>
+        {
+            EntityName = "Section",
+
+            CreateUniquenessChecks = [],
+
+            UpdateUniquenessChecks = [],
+
+            MapToEntity = section => new Section
+            {
+                Id = section.Id == Guid.Empty ? Guid.NewGuid() : section.Id,
+                Name = section.Name,
+                CourseId = section.CourseId,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            },
+
+            ApplyUpdate = (newData, existing) =>
+            {
+                if (!string.IsNullOrEmpty(newData.Name))
+                    existing.Name = newData.Name;
+                if (newData.CourseId != Guid.Empty)
+                    existing.CourseId = newData.CourseId;
+                existing.UpdatedAt = DateTime.UtcNow;
+            },
+
+            ResolveUniqueConstraintViolation = null,
+
+            ResolveForeignKeyViolation = ex =>
+            {
+                var message = ex.InnerException?.Message ?? ex.Message;
+                if (message.Contains("schedule", StringComparison.OrdinalIgnoreCase))
+                    return ("schedules", "Cannot delete: Section has schedules assigned. Remove schedules first.");
+                if (message.Contains("enrollment", StringComparison.OrdinalIgnoreCase))
+                    return ("enrollments", "Cannot delete: Section has student enrollments. Remove enrollments first.");
+                if (message.Contains("student", StringComparison.OrdinalIgnoreCase))
+                    return ("students", "Cannot delete: Section has students assigned. Remove students first.");
+                return null;
+            }
+        };
+    }
+}

--- a/attendance_monitoring/Services/Crud/SubjectConfig.cs
+++ b/attendance_monitoring/Services/Crud/SubjectConfig.cs
@@ -1,0 +1,75 @@
+using attendance_monitoring.Classes;
+using attendance_monitoring.IRepository;
+using attendance_monitoring.Models.DTO.Request;
+
+namespace attendance_monitoring.Services.Crud;
+
+/// <summary>
+/// CRUD configuration for the Subject entity.
+/// </summary>
+public static class SubjectConfig
+{
+    public static CrudServiceConfig<Subject, CreateSubject, UpdateSubject> Create(
+        ISubjectRepository subjectRepository)
+    {
+        return new CrudServiceConfig<Subject, CreateSubject, UpdateSubject>
+        {
+            EntityName = "Subject",
+
+            CreateUniquenessChecks =
+            [
+                new UniquenessCheck<CreateSubject>
+                {
+                    FieldName = "Code",
+                    ValueSelector = dto => dto.Code,
+                    ExistsAsync = async code =>
+                        await subjectRepository.GetSubjectByCodeAsync(code).ConfigureAwait(false) != null
+                }
+            ],
+
+            UpdateUniquenessChecks =
+            [
+                new UpdateUniquenessCheck<Subject, UpdateSubject>
+                {
+                    FieldName = "Code",
+                    ValueSelector = dto => dto.Code,
+                    CurrentValueSelector = entity => entity.Code,
+                    FindByUniqueFieldAsync = async code =>
+                        await subjectRepository.GetSubjectByCodeAsync(code).ConfigureAwait(false)
+                }
+            ],
+
+            MapToEntity = dto => new Subject
+            {
+                Id = Guid.NewGuid(),
+                Name = dto.Name,
+                Code = dto.Code,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            },
+
+            ApplyUpdate = (dto, entity) =>
+            {
+                if (!string.IsNullOrEmpty(dto.Name))
+                    entity.Name = dto.Name;
+                if (!string.IsNullOrEmpty(dto.Code))
+                    entity.Code = dto.Code;
+                entity.UpdatedAt = DateTime.UtcNow;
+            },
+
+            ResolveUniqueConstraintViolation = _ => ("Code", ""),
+
+            ResolveForeignKeyViolation = ex =>
+            {
+                var message = ex.InnerException?.Message ?? ex.Message;
+                if (message.Contains("FK_StudentEnrollments", StringComparison.OrdinalIgnoreCase)
+                    || message.Contains("StudentEnrollments", StringComparison.OrdinalIgnoreCase))
+                    return ("enrollments", "Cannot delete: Subject has student enrollments. Remove enrollments first.");
+                if (message.Contains("FK_Schedules_Subjects", StringComparison.OrdinalIgnoreCase)
+                    || message.Contains("Schedules", StringComparison.OrdinalIgnoreCase))
+                    return ("schedules", "Cannot delete: Subject has schedules assigned. Remove schedules first.");
+                return null;
+            }
+        };
+    }
+}

--- a/attendance_monitoring/Services/SectionService.cs
+++ b/attendance_monitoring/Services/SectionService.cs
@@ -1,393 +1,239 @@
 using attendance_monitoring.Classes;
 using attendance_monitoring.Exceptions;
-using attendance_monitoring.Helpers;
 using attendance_monitoring.IRepository;
 using attendance_monitoring.IServices;
 using attendance_monitoring.Models.DTO.Response;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
+using attendance_monitoring.Services.Crud;
 
-namespace attendance_monitoring.Services
+namespace attendance_monitoring.Services;
+
+/// <summary>
+/// Service class for managing section-related operations.
+/// Delegates CRUD operations to the generic CrudService; handles entity-specific
+/// DTO mapping, student queries, and dependency checks via the section repository.
+/// </summary>
+public class SectionService : ISectionService
 {
-    public class SectionService(ISectionRepository sectionRepository, ILogger<SectionService> logger)
-        : ISectionService
+    private readonly ICrudService<Section, Section, Section> _crudService;
+    private readonly ISectionRepository _sectionRepository;
+    private readonly ILogger<SectionService> _logger;
+
+    public SectionService(
+        ICrudService<Section, Section, Section> crudService,
+        ISectionRepository sectionRepository,
+        ILogger<SectionService> logger)
     {
-        #region Get Operations
-        /// <summary>
-        /// Retrieves a specific section by ID
-        /// </summary>
-        /// <param name="sectionId">The ID of the section to retrieve</param>
-        /// <returns>The section with the specified ID</returns>
-        /// <exception cref="T:attendance_monitoring.Exceptions.EntityNotFoundException{System.Int32}">Thrown when the section is not found</exception>
-        /// <exception cref="EntityServiceException">Thrown when an error occurs during retrieval</exception>
-        public async Task<Section> GetSectionByIdAsync(Guid sectionId)
-        {
-            try
-            {
-                var section = await sectionRepository.GetSectionByIdAsync(sectionId).ConfigureAwait(false);
-                if (section == null)
-                {
-                    logger.LogWarning("Section with ID {SectionId} not found", sectionId);
-                    throw new EntityNotFoundException<Guid>("Section", sectionId);
-                }
-
-                logger.LogInformation("Successfully retrieved section with ID: {SectionId}", sectionId);
-                return section;
-            }
-            catch (EntityNotFoundException<Guid>)
-            {
-                // Re-throw EntityNotFoundException as-is
-                throw;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "An error occurred while retrieving section with ID {SectionId} from repository.", sectionId);
-                throw new EntityServiceException("Section", $"GetSectionById: {sectionId}", "An error occurred while retrieving the section", ex);
-            }
-        }
-
-        public async Task<Section> GetSectionByUuidAsync(Guid id)
-        {
-            try
-            {
-                var section = await sectionRepository.GetSectionByUuidAsync(id).ConfigureAwait(false);
-                if (section == null)
-                {
-                    logger.LogWarning("Section with UUID {SectionId} not found", id);
-                    throw new EntityNotFoundException<Guid>("Section", id);
-                }
-
-                logger.LogInformation("Successfully retrieved section with UUID: {SectionId}", id);
-                return section;
-            }
-            catch (EntityNotFoundException<Guid>)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "An error occurred while retrieving section with UUID {SectionId} from repository.", id);
-                throw new EntityServiceException("Section", $"GetSectionByUuid: {id}", "An error occurred while retrieving the section", ex);
-            }
-        }
-
-        /// <summary>
-        /// Retrieves all sections
-        /// </summary>
-        /// <returns>A collection of section response DTOs</returns>
-        /// <exception cref="EntityServiceException">Thrown when an error occurs during retrieval</exception>
-        public async Task<IEnumerable<SectionResponseDto>> GetAllSectionsAsync()
-        {
-            try
-            {
-                logger.LogInformation("Retrieving all sections");
-                var sections = await sectionRepository.GetAllSectionsAsync().ConfigureAwait(false);
-                var sectionDtos = sections.Select(s => new SectionResponseDto
-                {
-                    Id = s.Id,
-                    Name = s.Name,
-                    CourseId = s.Course?.Id,
-                    CreatedAt = s.CreatedAt,
-                    UpdatedAt = s.UpdatedAt
-                }).ToList();
-
-                logger.LogInformation("Successfully retrieved {Count} sections", sectionDtos.Count);
-                return sectionDtos;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "An error occurred while retrieving all sections from repository.");
-                throw new EntityServiceException("Section", "GetAllSections", "An error occurred while retrieving sections", ex);
-            }
-        }
-
-        #endregion
-
-        #region Create Operations
-        /// <summary>
-        /// Creates a new section
-        /// </summary>
-        /// <param name="section">The section to create</param>
-        /// <returns>The created section response DTO</returns>
-        /// <exception cref="EntityServiceException">Thrown when section creation fails</exception>
-        public async Task<SectionResponseDto> CreateSectionAsync(Section section)
-        {
-            try
-            {
-                logger.LogInformation("Creating new section with name: {SectionName}", section.Name);
-                var createdSection = await sectionRepository.CreateSectionAsync(section).ConfigureAwait(false);
-                await sectionRepository.SaveChangesAsync().ConfigureAwait(false);
-
-                var refreshedSection = await sectionRepository.GetSectionByIdAsync(createdSection.Id).ConfigureAwait(false);
-                if (refreshedSection == null)
-                {
-                    logger.LogError("Created section with ID {SectionId} could not be found after save.", createdSection.Id);
-                    throw new InvalidOperationException("Created section could not be reloaded.");
-                }
-
-                var sectionDto = new SectionResponseDto
-                {
-                    Id = refreshedSection.Id,
-                    Name = refreshedSection.Name,
-                    CourseId = refreshedSection.Course?.Id,
-                    CreatedAt = refreshedSection.CreatedAt,
-                    UpdatedAt = refreshedSection.UpdatedAt
-                };
-
-                logger.LogInformation("Successfully created section with ID: {SectionId}", createdSection.Id);
-                return sectionDto;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "An error occurred while creating section with name {SectionName} in repository.", section.Name);
-                throw new EntityServiceException("Section", "CreateSection", "An error occurred while creating the section", ex);
-            }
-        }
-
-        #endregion
-
-        #region Update Operations
-        /// <summary>
-        /// Updates an existing section
-        /// </summary>
-        /// <param name="id">The ID of the section to update</param>
-        /// <param name="section">The updated section data</param>
-        /// <returns>The updated section response DTO</returns>
-        /// <exception cref="T:attendance_monitoring.Exceptions.EntityNotFoundException{System.Int32}">Thrown when the section is not found</exception>
-        /// <exception cref="EntityServiceException">Thrown when section update fails</exception>
-        public async Task<SectionResponseDto> UpdateSectionAsync(Guid id, Section section)
-        {
-            try
-            {
-                logger.LogInformation("Updating section with ID: {SectionId}", id);
-                var updatedSection = await sectionRepository.UpdateSectionAsync(id, section).ConfigureAwait(false);
-                if (updatedSection == null)
-                {
-                    logger.LogWarning("Section with ID {SectionId} not found for update in repository.", id);
-                    throw new EntityNotFoundException<Guid>("Section", id);
-                }
-
-                await sectionRepository.SaveChangesAsync().ConfigureAwait(false);
-
-                var refreshedSection = await sectionRepository.GetSectionByIdAsync(updatedSection.Id).ConfigureAwait(false);
-                if (refreshedSection == null)
-                {
-                    logger.LogError("Updated section with ID {SectionId} could not be found after save.", updatedSection.Id);
-                    throw new InvalidOperationException("Updated section could not be reloaded.");
-                }
-
-                var sectionDto = new SectionResponseDto
-                {
-                    Id = refreshedSection.Id,
-                    Name = refreshedSection.Name,
-                    CourseId = refreshedSection.Course?.Id,
-                    CreatedAt = refreshedSection.CreatedAt,
-                    UpdatedAt = refreshedSection.UpdatedAt
-                };
-
-                logger.LogInformation("Successfully updated section with ID: {SectionId}", id);
-                return sectionDto;
-            }
-            catch (EntityNotFoundException<Guid>)
-            {
-                // Re-throw EntityNotFoundException as-is
-                throw;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "An error occurred while updating section with ID {SectionId} in repository.", id);
-                throw new EntityServiceException("Section", $"UpdateSection: {id}", "An error occurred while updating the section", ex);
-            }
-        }
-
-        public async Task<SectionResponseDto> UpdateSectionByUuidAsync(Guid id, Section section)
-        {
-            var existingSection = await GetSectionByUuidAsync(id).ConfigureAwait(false);
-            return await UpdateSectionAsync(existingSection.Id, section).ConfigureAwait(false);
-        }
-
-        #endregion
-
-        #region Delete Operations
-        /// <summary>
-        /// Deletes a section by ID
-        /// </summary>
-        /// <param name="id">The ID of the section to delete</param>
-        /// <exception cref="T:attendance_monitoring.Exceptions.EntityNotFoundException{System.Int32}">Thrown when the section is not found</exception>
-        /// <exception cref="EntityConflictException">Thrown when section deletion is blocked by existing dependencies</exception>
-        /// <exception cref="EntityServiceException">Thrown when section deletion fails unexpectedly</exception>
-        public async Task DeleteSectionAsync(Guid id)
-        {
-            try
-            {
-                logger.LogInformation("Deleting section with ID: {SectionId}", id);
-                var result = await sectionRepository.DeleteSectionAsync(id).ConfigureAwait(false);
-                if (!result)
-                {
-                    logger.LogWarning("Section with ID {SectionId} not found for deletion", id);
-                    throw new EntityNotFoundException<Guid>("Section", id);
-                }
-
-                await sectionRepository.SaveChangesAsync().ConfigureAwait(false);
-                logger.LogInformation("Successfully deleted section with ID: {SectionId}", id);
-            }
-            catch (EntityNotFoundException<Guid>)
-            {
-                // Re-throw EntityNotFoundException as-is
-                throw;
-            }
-            catch (DbUpdateException ex) when (ExceptionHandlingHelper.IsForeignKeyViolation(ex))
-            {
-                // Translate FK constraint violations into EntityConflictException
-                var conflictMessage = ResolveConflictMessage(ex);
-                logger.LogWarning(ex, "Cannot delete section {SectionId}: {ConflictMessage}", id, conflictMessage);
-                throw new EntityConflictException("Section", ResolveConflictType(ex), conflictMessage, ex);
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "An error occurred while deleting section with ID {SectionId} from repository.", id);
-                throw new EntityServiceException("Section", $"DeleteSection: {id}", "An error occurred while deleting the section", ex);
-            }
-        }
-
-        public async Task DeleteSectionByUuidAsync(Guid id)
-        {
-            var existingSection = await GetSectionByUuidAsync(id).ConfigureAwait(false);
-            await DeleteSectionAsync(existingSection.Id).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Resolves the type of conflict based on the exception details.
-        /// </summary>
-        private static string ResolveConflictType(DbUpdateException ex)
-        {
-            var message = ex.InnerException?.Message ?? ex.Message;
-
-            if (message.Contains("schedule", StringComparison.OrdinalIgnoreCase))
-                return "schedules";
-            if (message.Contains("enrollment", StringComparison.OrdinalIgnoreCase))
-                return "enrollments";
-            if (message.Contains("student", StringComparison.OrdinalIgnoreCase))
-                return "students";
-
-            return "dependencies";
-        }
-
-        /// <summary>
-        /// Generates a user-friendly conflict message based on the exception details.
-        /// </summary>
-        private static string ResolveConflictMessage(DbUpdateException ex)
-        {
-            var message = ex.InnerException?.Message ?? ex.Message;
-
-            if (message.Contains("schedule", StringComparison.OrdinalIgnoreCase))
-                return "Cannot delete: Section has schedules assigned. Remove schedules first.";
-            if (message.Contains("enrollment", StringComparison.OrdinalIgnoreCase))
-                return "Cannot delete: Section has student enrollments. Remove enrollments first.";
-            if (message.Contains("student", StringComparison.OrdinalIgnoreCase))
-                return "Cannot delete: Section has assigned students. Reassign students first.";
-
-            return "Cannot delete: Section has dependencies that prevent deletion.";
-        }
-
-        #endregion
-
-        #region Get Operations (Additional)
-        /// <summary>
-        /// Retrieves active students by section ID
-        /// </summary>
-        /// <param name="sectionId">The ID of the section</param>
-        /// <returns>A collection of active students</returns>
-        /// <exception cref="EntityServiceException">Thrown when an error occurs during retrieval</exception>
-        public async Task<IEnumerable<Student>> GetActiveStudentsBySectionIdAsync(Guid sectionId)
-        {
-            try
-            {
-                logger.LogInformation("Retrieving active students for section with ID: {SectionId}", sectionId);
-                var students = await sectionRepository.GetActiveStudentsBySectionIdAsync(sectionId).ConfigureAwait(false);
-                var studentList = students.ToList();
-                logger.LogInformation("Successfully retrieved {Count} active students for section with ID: {SectionId}", studentList.Count, sectionId);
-                return studentList;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "An error occurred while retrieving active students for section with ID {SectionId} from repository.", sectionId);
-                throw new EntityServiceException("Section", $"GetActiveStudentsBySectionId: {sectionId}", "An error occurred while retrieving active students", ex);
-            }
-        }
-
-        /// <summary>
-        /// Retrieves all students by section ID
-        /// </summary>
-        /// <param name="sectionId">The ID of the section</param>
-        /// <returns>A collection of all students</returns>
-        /// <exception cref="EntityServiceException">Thrown when an error occurs during retrieval</exception>
-        public async Task<IEnumerable<Student>> GetAllStudentsBySectionIdAsync(Guid sectionId)
-        {
-            try
-            {
-                logger.LogInformation("Retrieving all students for section with ID: {SectionId}", sectionId);
-                var students = await sectionRepository.GetAllStudentsBySectionIdAsync(sectionId).ConfigureAwait(false);
-                var studentList = students.ToList();
-                logger.LogInformation("Successfully retrieved {Count} students for section with ID: {SectionId}", studentList.Count, sectionId);
-                return studentList;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "An error occurred while retrieving all students for section with ID {SectionId} from repository.", sectionId);
-                throw new EntityServiceException("Section", $"GetAllStudentsBySectionId: {sectionId}", "An error occurred while retrieving students", ex);
-            }
-        }
-        #endregion
-
-        #region Dependency Check Operations
-        public async Task<bool> HasStudentsInSectionAsync(Guid sectionId)
-        {
-            try
-            {
-                logger.LogInformation("Checking if section {SectionId} has students", sectionId);
-                var hasStudents = await sectionRepository.HasStudentsInSectionAsync(sectionId).ConfigureAwait(false);
-                logger.LogInformation("Section {SectionId} has students: {HasStudents}", sectionId, hasStudents);
-                return hasStudents;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error checking if section {SectionId} has students", sectionId);
-                throw new EntityServiceException("Section", $"HasStudentsInSection: {sectionId}", "Error checking section dependencies", ex);
-            }
-        }
-
-        public async Task<bool> HasStudentEnrollmentsInSectionAsync(Guid sectionId)
-        {
-            try
-            {
-                logger.LogInformation("Checking if section {SectionId} has student enrollments", sectionId);
-                var hasEnrollments = await sectionRepository.HasStudentEnrollmentsInSectionAsync(sectionId).ConfigureAwait(false);
-                logger.LogInformation("Section {SectionId} has student enrollments: {HasEnrollments}", sectionId, hasEnrollments);
-                return hasEnrollments;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error checking if section {SectionId} has student enrollments", sectionId);
-                throw new EntityServiceException("Section", $"HasStudentEnrollmentsInSection: {sectionId}", "Error checking section dependencies", ex);
-            }
-        }
-
-        public async Task<bool> HasSchedulesInSectionAsync(Guid sectionId)
-        {
-            try
-            {
-                logger.LogInformation("Checking if section {SectionId} has schedules", sectionId);
-                var hasSchedules = await sectionRepository.HasSchedulesInSectionAsync(sectionId).ConfigureAwait(false);
-                logger.LogInformation("Section {SectionId} has schedules: {HasSchedules}", sectionId, hasSchedules);
-                return hasSchedules;
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Error checking if section {SectionId} has schedules", sectionId);
-                throw new EntityServiceException("Section", $"HasSchedulesInSection: {sectionId}", "Error checking section dependencies", ex);
-            }
-        }
-        #endregion
+        _crudService = crudService;
+        _sectionRepository = sectionRepository;
+        _logger = logger;
     }
+
+    #region Read Operations
+
+    public async Task<Section> GetSectionByIdAsync(Guid sectionId)
+    {
+        try
+        {
+            var section = await _sectionRepository.GetSectionByIdAsync(sectionId).ConfigureAwait(false);
+            if (section == null)
+                throw new EntityNotFoundException<Guid>("Section", sectionId);
+            return section;
+        }
+        catch (EntityNotFoundException<Guid>)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An error occurred while retrieving section with ID {SectionId} from repository.", sectionId);
+            throw new EntityServiceException("Section", $"GetSectionById: {sectionId}", "An error occurred while retrieving the section", ex);
+        }
+    }
+
+    public async Task<Section> GetSectionByUuidAsync(Guid id)
+    {
+        try
+        {
+            var section = await _sectionRepository.GetSectionByUuidAsync(id).ConfigureAwait(false);
+            if (section == null)
+                throw new EntityNotFoundException<Guid>("Section", id);
+            return section;
+        }
+        catch (EntityNotFoundException<Guid>)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An error occurred while retrieving section with UUID {SectionId} from repository.", id);
+            throw new EntityServiceException("Section", $"GetSectionByUuid: {id}", "An error occurred while retrieving the section", ex);
+        }
+    }
+
+    public async Task<IEnumerable<SectionResponseDto>> GetAllSectionsAsync()
+    {
+        try
+        {
+            _logger.LogInformation("Retrieving all sections");
+            var sections = await _sectionRepository.GetAllSectionsAsync().ConfigureAwait(false);
+            var sectionDtos = sections.Select(MapToDto).ToList();
+            _logger.LogInformation("Successfully retrieved {Count} sections", sectionDtos.Count);
+            return sectionDtos;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An error occurred while retrieving all sections from repository.");
+            throw new EntityServiceException("Section", "GetAllSections", "An error occurred while retrieving sections", ex);
+        }
+    }
+
+    #endregion
+
+    #region Create Operations
+
+    public async Task<SectionResponseDto> CreateSectionAsync(Section section)
+    {
+        var created = await _crudService.CreateAsync(section).ConfigureAwait(false);
+        return await RefreshAndMapAsync(created.Id, "CreateSection").ConfigureAwait(false);
+    }
+
+    #endregion
+
+    #region Update Operations
+
+    public async Task<SectionResponseDto> UpdateSectionAsync(Guid id, Section section)
+    {
+        var updated = await _crudService.UpdateAsync(id, section).ConfigureAwait(false);
+        return await RefreshAndMapAsync(updated.Id, "UpdateSection").ConfigureAwait(false);
+    }
+
+    public async Task<SectionResponseDto> UpdateSectionByUuidAsync(Guid id, Section section)
+    {
+        var updated = await _crudService.UpdateAsync(id, section).ConfigureAwait(false);
+        return await RefreshAndMapAsync(updated.Id, "UpdateSection").ConfigureAwait(false);
+    }
+
+    #endregion
+
+    #region Delete Operations
+
+    public async Task DeleteSectionAsync(Guid id)
+    {
+        await _crudService.DeleteAsync(id).ConfigureAwait(false);
+    }
+
+    public async Task DeleteSectionByUuidAsync(Guid id)
+    {
+        await _crudService.DeleteAsync(id).ConfigureAwait(false);
+    }
+
+    #endregion
+
+    #region Student Operations (entity-specific)
+
+    public async Task<IEnumerable<Student>> GetActiveStudentsBySectionIdAsync(Guid sectionId)
+    {
+        try
+        {
+            var students = await _sectionRepository.GetActiveStudentsBySectionIdAsync(sectionId).ConfigureAwait(false);
+            return students;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An error occurred while retrieving active students for section {SectionId}.", sectionId);
+            throw new EntityServiceException("Section", $"GetActiveStudentsBySectionId: {sectionId}", "An error occurred while retrieving active students", ex);
+        }
+    }
+
+    public async Task<IEnumerable<Student>> GetAllStudentsBySectionIdAsync(Guid sectionId)
+    {
+        try
+        {
+            var students = await _sectionRepository.GetAllStudentsBySectionIdAsync(sectionId).ConfigureAwait(false);
+            return students;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An error occurred while retrieving students for section {SectionId}.", sectionId);
+            throw new EntityServiceException("Section", $"GetAllStudentsBySectionId: {sectionId}", "An error occurred while retrieving students", ex);
+        }
+    }
+
+    #endregion
+
+    #region Dependency Check Operations (entity-specific)
+
+    public async Task<bool> HasStudentsInSectionAsync(Guid sectionId)
+    {
+        try
+        {
+            _logger.LogInformation("Checking if section {SectionId} has students", sectionId);
+            var hasStudents = await _sectionRepository.HasStudentsInSectionAsync(sectionId).ConfigureAwait(false);
+            _logger.LogInformation("Section {SectionId} has students: {HasStudents}", sectionId, hasStudents);
+            return hasStudents;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error checking if section {SectionId} has students", sectionId);
+            throw new EntityServiceException("Section", $"HasStudentsInSection: {sectionId}", "Error checking section dependencies", ex);
+        }
+    }
+
+    public async Task<bool> HasStudentEnrollmentsInSectionAsync(Guid sectionId)
+    {
+        try
+        {
+            _logger.LogInformation("Checking if section {SectionId} has student enrollments", sectionId);
+            var hasEnrollments = await _sectionRepository.HasStudentEnrollmentsInSectionAsync(sectionId).ConfigureAwait(false);
+            _logger.LogInformation("Section {SectionId} has student enrollments: {HasEnrollments}", sectionId, hasEnrollments);
+            return hasEnrollments;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error checking if section {SectionId} has student enrollments", sectionId);
+            throw new EntityServiceException("Section", $"HasStudentEnrollmentsInSection: {sectionId}", "Error checking section dependencies", ex);
+        }
+    }
+
+    public async Task<bool> HasSchedulesInSectionAsync(Guid sectionId)
+    {
+        try
+        {
+            _logger.LogInformation("Checking if section {SectionId} has schedules", sectionId);
+            var hasSchedules = await _sectionRepository.HasSchedulesInSectionAsync(sectionId).ConfigureAwait(false);
+            _logger.LogInformation("Section {SectionId} has schedules: {HasSchedules}", sectionId, hasSchedules);
+            return hasSchedules;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error checking if section {SectionId} has schedules", sectionId);
+            throw new EntityServiceException("Section", $"HasSchedulesInSection: {sectionId}", "Error checking section dependencies", ex);
+        }
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private async Task<SectionResponseDto> RefreshAndMapAsync(Guid sectionId, string operation)
+    {
+        var refreshed = await _sectionRepository.GetSectionByIdAsync(sectionId).ConfigureAwait(false);
+        if (refreshed == null)
+        {
+            _logger.LogError("{Operation} succeeded but section {SectionId} could not be reloaded.", operation, sectionId);
+            throw new InvalidOperationException($"{operation} succeeded but section could not be reloaded.");
+        }
+        return MapToDto(refreshed);
+    }
+
+    private static SectionResponseDto MapToDto(Section s) => new()
+    {
+        Id = s.Id,
+        Name = s.Name,
+        CourseId = s.Course?.Id,
+        CreatedAt = s.CreatedAt,
+        UpdatedAt = s.UpdatedAt
+    };
+
+    #endregion
 }

--- a/attendance_monitoring/Services/SubjectService.cs
+++ b/attendance_monitoring/Services/SubjectService.cs
@@ -1,287 +1,79 @@
 using attendance_monitoring.Classes;
 using attendance_monitoring.Exceptions;
-using attendance_monitoring.Helpers;
 using attendance_monitoring.IRepository;
 using attendance_monitoring.IServices;
 using attendance_monitoring.Models.DTO.Request;
-using Microsoft.EntityFrameworkCore;
+using attendance_monitoring.Services.Crud;
 
 namespace attendance_monitoring.Services;
 
 /// <summary>
-/// Service class for managing subject-related operations
+/// Service class for managing subject-related operations.
+/// Delegates CRUD operations to the generic CrudService; handles entity-specific
+/// dependency checks via the subject repository.
 /// </summary>
 public class SubjectService : ISubjectService
 {
+    private readonly ICrudService<Subject, CreateSubject, UpdateSubject> _crudService;
     private readonly ISubjectRepository _subjectRepository;
     private readonly ILogger<SubjectService> _logger;
 
-    /// <summary>
-    /// Initializes a new instance of the SubjectService class
-    /// </summary>
-    /// <param name="subjectRepository">Repository for subject data operations</param>
-    /// <param name="logger">Logger for logging operations</param>
-    public SubjectService(ISubjectRepository subjectRepository, ILogger<SubjectService> logger)
+    public SubjectService(
+        ICrudService<Subject, CreateSubject, UpdateSubject> crudService,
+        ISubjectRepository subjectRepository,
+        ILogger<SubjectService> logger)
     {
-        _subjectRepository = subjectRepository ?? throw new ArgumentNullException(nameof(subjectRepository));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _crudService = crudService;
+        _subjectRepository = subjectRepository;
+        _logger = logger;
     }
 
-    #region Get Operations
+    #region CRUD Operations (delegated to CrudService)
 
-    /// <summary>
-    /// Retrieves all subjects
-    /// </summary>
-    /// <returns>A collection of subjects</returns>
     public async Task<IEnumerable<Subject>> GetAllSubjectsAsync()
     {
-        _logger.LogInformation("Retrieving all subjects");
-        try
-        {
-            var subjects = await _subjectRepository.GetAllSubjectsAsync().ConfigureAwait(false);
-            var allSubjects = subjects.ToList();
-            _logger.LogInformation("Successfully retrieved {Count} subjects", allSubjects.Count);
-            return allSubjects;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while retrieving all subjects");
-            throw new EntityServiceException("Subject", "GetAllSubjects", "An error occurred while retrieving subjects", ex);
-        }
+        return await _crudService.GetAllAsync().ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Retrieves a specific subject by ID
-    /// </summary>
-    /// <param name="id">The ID of the subject to retrieve</param>
-    /// <returns>The subject with the specified ID, or null if not found</returns>
     public async Task<Subject?> GetSubjectByIdAsync(Guid id)
     {
-        _logger.LogInformation("Retrieving subject by ID: {Id}", id);
-        try
-        {
-            var subject = await _subjectRepository.GetSubjectByIdAsync(id).ConfigureAwait(false);
-            if (subject == null)
-            {
-                _logger.LogWarning("Subject with ID {Id} not found", id);
-                throw new EntityNotFoundException<Guid>("Subject", id);
-            }
-
-            _logger.LogInformation("Successfully retrieved subject with ID: {Id}", id);
-            return subject;
-        }
-        catch (EntityNotFoundException<Guid>)
-        {
-            // Re-throw the specific exception for the controller to handle
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while retrieving subject with ID {Id}", id);
-            throw new EntityServiceException("Subject", $"GetSubjectById: {id}", "An error occurred while retrieving the subject", ex);
-        }
+        return await _crudService.GetByIdAsync(id).ConfigureAwait(false);
     }
 
     public async Task<Subject?> GetSubjectByUuidAsync(Guid id)
     {
-        _logger.LogInformation("Retrieving subject by UUID: {Id}", id);
-        try
-        {
-            var subject = await _subjectRepository.GetSubjectByUuidAsync(id).ConfigureAwait(false);
-            if (subject == null)
-            {
-                _logger.LogWarning("Subject with UUID {Id} not found", id);
-                throw new EntityNotFoundException<Guid>("Subject", id);
-            }
-
-            _logger.LogInformation("Successfully retrieved subject with UUID: {Id}", id);
-            return subject;
-        }
-        catch (EntityNotFoundException<Guid>)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while retrieving subject with UUID {Id}", id);
-            throw new EntityServiceException("Subject", $"GetSubjectByUuid: {id}", "An error occurred while retrieving the subject", ex);
-        }
+        return await _crudService.GetByIdAsync(id).ConfigureAwait(false);
     }
 
-    #endregion
-
-    #region Create Operations
-
-    /// <summary>
-    /// Creates a new subject record
-    /// </summary>
-    /// <param name="createSubject">The subject data to create</param>
-    /// <returns>The created subject</returns>
-    /// <exception cref="ValidationException">Thrown when validation fails</exception>
-    /// <exception cref="EntityAlreadyExistsException{TKey}">Thrown when subject with code already exists</exception>
-    /// <exception cref="EntityServiceException">Thrown when an error occurs during creation</exception>
     public async Task<Subject> CreateSubjectAsync(CreateSubject createSubject)
     {
-        _logger.LogInformation("Creating new subject with name: {SubjectName}", createSubject.Name);
-
-        try
-        {
-            if (string.IsNullOrWhiteSpace(createSubject.Name))
-            {
-                _logger.LogWarning("Subject creation failed: Subject name is required");
-                throw new ValidationException("Subject name is required");
-            }
-
-            if (string.IsNullOrWhiteSpace(createSubject.Code))
-            {
-                _logger.LogWarning("Subject creation failed: Subject code is required");
-                throw new ValidationException("Subject code is required");
-            }
-
-            // Check if a subject with the same code already exists (first check)
-            var existingSubject = await _subjectRepository.GetSubjectByCodeAsync(createSubject.Code);
-            if (existingSubject != null)
-            {
-                _logger.LogWarning("Subject creation failed: Subject with code {Code} already exists", createSubject.Code);
-                throw new EntityAlreadyExistsException<string>("Subject", "Code", createSubject.Code);
-            }
-
-            var subject = new Subject
-            {
-                Name = createSubject.Name,
-                Code = createSubject.Code,
-                CreatedAt = DateTime.UtcNow,
-                UpdatedAt = DateTime.UtcNow
-            };
-
-            try
-            {
-                var createdSubject = await _subjectRepository.CreateSubject(subject).ConfigureAwait(false);
-                await _subjectRepository.SaveChangesAsync().ConfigureAwait(false);
-
-                _logger.LogInformation("Successfully created subject with ID: {Id} and name: {SubjectName}", createdSubject.Id, createdSubject.Name);
-                return createdSubject;
-            }
-            catch (DbUpdateException ex) when (ExceptionHandlingHelper.IsUniqueConstraintViolation(ex))
-            {
-                _logger.LogWarning("Subject creation failed due to unique constraint violation: Subject with code {Code} already exists", createSubject.Code);
-                throw new EntityAlreadyExistsException<string>("Subject", "Code", createSubject.Code);
-            }
-        }
-        catch (ValidationException)
-        {
-            throw;
-        }
-        catch (EntityAlreadyExistsException<string>)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while creating subject with name: {SubjectName}", createSubject.Name);
-            throw ExceptionHandlingHelper.CreateServiceException("Subject", "CreateSubject", ex);
-        }
+        return await _crudService.CreateAsync(createSubject).ConfigureAwait(false);
     }
 
-    #endregion
-
-    #region Update Operations
-
-    /// <summary>
-    /// Updates an existing subject record
-    /// </summary>
-    /// <param name="id">The ID of the subject to update</param>
-    /// <param name="updateSubject">The updated subject data</param>
-    /// <returns>The updated subject</returns>
-    /// <exception cref="EntityNotFoundException{TKey}">Thrown when subject not found</exception>
-    /// <exception cref="EntityAlreadyExistsException{TKey}">Thrown when subject with code already exists</exception>
-    /// <exception cref="EntityServiceException">Thrown when an error occurs during update</exception>
     public async Task<Subject> UpdateSubjectAsync(Guid id, UpdateSubject updateSubject)
     {
-        _logger.LogInformation("Updating subject with ID: {Id}", id);
-
-        try
-        {
-
-            var existingSubject = await _subjectRepository.GetSubjectByIdAsync(id).ConfigureAwait(false);
-            if (existingSubject == null)
-            {
-                _logger.LogWarning("Subject update failed: Subject with ID {Id} not found", id);
-                throw new EntityNotFoundException<Guid>("Subject", id);
-            }
-
-            // Check if the new code already exists for another subject (first check)
-            if (!string.IsNullOrEmpty(updateSubject.Code) && !updateSubject.Code.Equals(existingSubject.Code))
-            {
-                var duplicateSubject = await _subjectRepository.GetSubjectByCodeAsync(updateSubject.Code);
-                if (duplicateSubject != null && duplicateSubject.Id != id)
-                {
-                    _logger.LogWarning("Subject update failed: Subject with code {Code} already exists", updateSubject.Code);
-                    throw new EntityAlreadyExistsException<string>("Subject", "Code", updateSubject.Code);
-                }
-            }
-
-            if (!string.IsNullOrEmpty(updateSubject.Name))
-            {
-                existingSubject.Name = updateSubject.Name;
-            }
-
-            if (!string.IsNullOrEmpty(updateSubject.Code))
-            {
-                existingSubject.Code = updateSubject.Code;
-            }
-
-            existingSubject.UpdatedAt = DateTime.UtcNow;
-
-            try
-            {
-                var updatedSubject = await _subjectRepository.UpdateSubjectAsync(existingSubject).ConfigureAwait(false);
-                var rowsAffected = await _subjectRepository.SaveChangesAsync().ConfigureAwait(false);
-
-                if (rowsAffected == 0)
-                {
-                    _logger.LogWarning("Subject update failed: Subject with ID {Id} may have been updated by another process", id);
-                    throw new EntityServiceException("Subject", $"UpdateSubject: {id}", "Subject may have been updated by another process. Please try again.");
-                }
-
-                _logger.LogInformation("Successfully updated subject with ID: {Id}", id);
-                return updatedSubject;
-            }
-            catch (DbUpdateException ex) when (ExceptionHandlingHelper.IsUniqueConstraintViolation(ex))
-            {
-                _logger.LogWarning("Subject update failed due to unique constraint violation: Subject with code {Code} already exists", updateSubject.Code);
-                throw new EntityAlreadyExistsException<string>("Subject", "Code", updateSubject.Code ?? "");
-            }
-        }
-        catch (EntityNotFoundException<Guid>)
-        {
-            // Re-throw the specific exception for the controller to handle
-            throw;
-        }
-        catch (EntityAlreadyExistsException<string>)
-        {
-            throw;
-        }
-        catch (EntityServiceException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while updating subject with ID {Id}", id);
-            throw ExceptionHandlingHelper.CreateServiceException("Subject", $"UpdateSubject: {id}", ex);
-        }
+        return await _crudService.UpdateAsync(id, updateSubject).ConfigureAwait(false);
     }
 
     public async Task<Subject> UpdateSubjectByUuidAsync(Guid id, UpdateSubject updateSubject)
     {
-        var existingSubject = await GetSubjectByUuidAsync(id).ConfigureAwait(false);
-        return await UpdateSubjectAsync(existingSubject!.Id, updateSubject).ConfigureAwait(false);
+        return await _crudService.UpdateAsync(id, updateSubject).ConfigureAwait(false);
+    }
+
+    public async Task DeleteSubjectAsync(Guid id)
+    {
+        await _crudService.DeleteAsync(id).ConfigureAwait(false);
+    }
+
+    public async Task DeleteSubjectByUuidAsync(Guid id)
+    {
+        await _crudService.DeleteAsync(id).ConfigureAwait(false);
     }
 
     #endregion
 
-    #region Dependency Check Operations
+    #region Dependency Check Operations (entity-specific)
+
     public async Task<bool> HasSchedulesInSubjectAsync(Guid id)
     {
         try
@@ -313,98 +105,6 @@ public class SubjectService : ISubjectService
             throw new EntityServiceException("Subject", $"HasEnrollmentsInSubject: {id}", "Error checking subject dependencies", ex);
         }
     }
-    #endregion
-
-    #region Delete Operations
-
-    /// <summary>
-    /// Deletes a subject by ID
-    /// </summary>
-    /// <param name="id">The ID of the subject to delete</param>
-    /// <exception cref="EntityNotFoundException{TKey}">Thrown when subject not found</exception>
-    /// <exception cref="EntityServiceException">Thrown when an error occurs during deletion</exception>
-    public async Task DeleteSubjectAsync(Guid id)
-    {
-        _logger.LogInformation("Deleting subject with ID: {Id}", id);
-
-        try
-        {
-            var existingSubject = await _subjectRepository.GetSubjectByIdAsync(id).ConfigureAwait(false);
-            if (existingSubject == null)
-            {
-                _logger.LogWarning("Subject deletion failed: Subject with ID {Id} not found", id);
-                throw new EntityNotFoundException<Guid>("Subject", id);
-            }
-
-            var result = await _subjectRepository.DeleteSubjectAsync(id).ConfigureAwait(false);
-            if (!result)
-            {
-                _logger.LogError("Subject deletion failed: Failed to delete subject with ID {Id}", id);
-                throw new EntityServiceException("Subject", $"DeleteSubject: {id}", "Failed to delete subject");
-            }
-
-            var rowsAffected = await _subjectRepository.SaveChangesAsync().ConfigureAwait(false);
-            if (rowsAffected == 0)
-            {
-                _logger.LogWarning("Subject deletion failed: Subject with ID {Id} may have been deleted by another process", id);
-                throw new EntityServiceException("Subject", $"DeleteSubject: {id}", "Subject may have been deleted by another process.");
-            }
-            _logger.LogInformation("Successfully deleted subject with ID: {Id}", id);
-        }
-        catch (EntityNotFoundException<Guid>)
-        {
-            // Re-throw the specific exception for the controller to handle
-            throw;
-        }
-        catch (EntityServiceException)
-        {
-            throw;
-        }
-        catch (DbUpdateException ex) when (ExceptionHandlingHelper.IsForeignKeyViolation(ex))
-        {
-            var conflictType = ResolveDeleteConflictType(ex);
-            var conflictMessage = ResolveDeleteConflictMessage(conflictType);
-            _logger.LogWarning(ex, "Subject deletion failed due to foreign key constraint: {Message}", conflictMessage);
-            throw new EntityConflictException("Subject", conflictType, conflictMessage, ex);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error occurred while deleting subject with ID {Id}", id);
-            throw ExceptionHandlingHelper.CreateServiceException("Subject", $"DeleteSubject: {id}", ex);
-        }
-    }
-
-    public async Task DeleteSubjectByUuidAsync(Guid id)
-    {
-        var existingSubject = await GetSubjectByUuidAsync(id).ConfigureAwait(false);
-        await DeleteSubjectAsync(existingSubject!.Id).ConfigureAwait(false);
-    }
 
     #endregion
-
-    private static string ResolveDeleteConflictType(DbUpdateException ex)
-    {
-        var message = ex.InnerException?.Message ?? ex.Message;
-        if (message.Contains("FK_StudentEnrollments", StringComparison.OrdinalIgnoreCase) || message.Contains("StudentEnrollments", StringComparison.OrdinalIgnoreCase))
-        {
-            return "enrollments";
-        }
-
-        if (message.Contains("FK_Schedules_Subjects", StringComparison.OrdinalIgnoreCase) || message.Contains("Schedules", StringComparison.OrdinalIgnoreCase))
-        {
-            return "schedules";
-        }
-
-        return "dependencies";
-    }
-
-    private static string ResolveDeleteConflictMessage(string conflictType)
-    {
-        return conflictType switch
-        {
-            "schedules" => "Cannot delete: Subject has schedules assigned. Remove schedules first.",
-            "enrollments" => "Cannot delete: Subject has student enrollments. Remove enrollments first.",
-            _ => "Cannot delete: Subject has dependencies that prevent deletion.",
-        };
-    }
 }


### PR DESCRIPTION
- refactor 4 services that had exact saem boilerplate to use generic module which returns raw entities and then callers just map to DTOs
- the other classes use repo directly for reads and uniqueness checks are declarative collection, not lambda